### PR TITLE
Rename USE command to GET and clean up alias resolution

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-pack
-description: "Pack, share, and load context using Epismo context packs. Trigger on: 'pack this', 'new pack', 'use <id>', 'load my context', 'what context do I have', 'restore session', 'save this context', 'share with my team', 'pack this up', 'hand this off', 'publish this guide', 'organize my packs', or any intent to persist or retrieve knowledge across tools or sessions."
+description: "Pack, share, and load context using Epismo context packs. Trigger on: 'pack this', 'new pack', 'get <id>', 'read <alias>', 'load my context', 'what context do I have', 'restore session', 'save this context', 'share with my team', 'pack this up', 'hand this off', 'publish this guide', 'organize my packs', or any intent to persist or retrieve knowledge across tools or sessions."
 ---
 
 # Context Pack
@@ -20,7 +20,7 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 | `pack`                 | pack this, save this, summarize session                               | [PACK](#pack)         |
 | `new`                  | new pack, start fresh, hand off a task, share project status          | [NEW](#new)           |
 | `publish [<id>]`       | publish this, make this public, publish a guide, share with community | [PUBLISH](#publish)   |
-| `use <id\|alias>`      | load this ID, restore from ID, load alias                             | [USE](#use)           |
+| `get <id\|alias>`      | get this ID, load this ID, restore from ID, read alias, open alias    | [GET](#get)           |
 | `find <query>`         | what context do I have, load my context, search                       | [FIND](#find)         |
 | `update [<id\|alias>]` | edit this pack, update my last pack                                   | [UPDATE](#update)     |
 | `organize`             | reorganize blocks, split this, clean up                               | [ORGANIZE](#organize) |
@@ -28,17 +28,17 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 
 ## Operations (context packs)
 
-| Operation      | CLI                                                                                                        | MCP                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- |
-| `search pack`  | `epismo pack search --type context [--query <keywords>] [--filter '{...}']`                                | `epismo_pack_search` |
-| `get pack`     | `epismo pack get --id <id> [--full] [--block-id <id>]`<br>`epismo pack get --type context --alias <alias>` | `epismo_pack_get`    |
-| `upsert pack`  | `epismo pack upsert --input '<json>'`                                                                      | `epismo_pack_upsert` |
-| `delete pack`  | `epismo pack delete --id <id>`                                                                             | `epismo_pack_delete` |
-| `like pack`    | `epismo pack like --id <id> --liked`                                                                       | `epismo_pack_like`   |
-| `upsert alias` | `epismo alias upsert --type context --id <id> --alias <name>`                                              | —                    |
-| `get alias`    | `epismo alias get --alias <name>`                                                                          | —                    |
-| `list aliases` | `epismo alias list --type context`                                                                         | —                    |
-| `delete alias` | `epismo alias delete --alias <name>`                                                                       | —                    |
+| Operation      | CLI                                                                                         | MCP                  |
+| -------------- | ------------------------------------------------------------------------------------------- | -------------------- |
+| `search pack`  | `epismo pack search --type context [--query <keywords>] [--filter '{...}']`                 | `epismo_pack_search` |
+| `get pack`     | `epismo pack get --id <id> [--full] [--block-id <id>]`<br>`epismo pack get --alias <alias>` | `epismo_pack_get`    |
+| `upsert pack`  | `epismo pack upsert --input '<json>'`                                                       | `epismo_pack_upsert` |
+| `delete pack`  | `epismo pack delete --id <id>`                                                              | `epismo_pack_delete` |
+| `like pack`    | `epismo pack like --id <id> --liked`                                                        | `epismo_pack_like`   |
+| `upsert alias` | `epismo alias upsert --type context --id <id> --alias <name>`                               | —                    |
+| `get alias`    | `epismo alias get --alias <name>`                                                           | —                    |
+| `list aliases` | `epismo alias list --type context`                                                          | —                    |
+| `delete alias` | `epismo alias delete --alias <name>`                                                        | —                    |
 
 ---
 
@@ -215,21 +215,31 @@ share    https://epismo.ai/hub/contexts/<id>
 
 ---
 
-## USE
+## GET
 
-**Goal:** load a pack when the user gives an ID, an alias, or a short label that might be either.
+**Goal:** fetch a pack by ID, alias, or explicit read/open target.
+
+### Route intent before resolving
+
+Prefer **alias-first** unless the input is obviously a search query.
+
+| Input pattern                                                           | Route         | Why                                           |
+| ----------------------------------------------------------------------- | ------------- | --------------------------------------------- |
+| `get ...`, `use ...`, `load ...`, `open ...`, `read ...`, `restore ...` | [GET](#get)   | Explicit retrieval                            |
+| `find ...`, `search ...`, `what context do I have`, `show my packs`     | [FIND](#find) | Explicit discovery                            |
+| Bare UUID                                                               | [GET](#get)   | IDs are unambiguous                           |
+| Short ambiguous phrase                                                  | [GET](#get)   | Try alias first, then search if it misses     |
+| Obvious search query, question, or long descriptive phrase              | [FIND](#find) | Discovery intent is clearer than alias intent |
 
 ### Resolve the input
 
-| Input looks like    | Try first             | Fallback                                        |
-| ------------------- | --------------------- | ----------------------------------------------- |
-| UUID                | `get pack` by `id`    | —                                               |
-| `@handle/name`      | `get pack` by `alias` | tell user if not found                          |
-| short word / phrase | `get pack` by `alias` | if not found → [FIND](#find) with it as keyword |
+1. UUID → `get pack --id`.
+2. `@handle/name` or one compact token like `weekly-handoff` → `get pack --alias`; if it misses, run [FIND](#find) with the same text.
+3. Short phrase like `auth refactor handoff` → try `get pack --alias` first; if it misses, run [FIND](#find).
+4. Question, explicit search wording, or long descriptive text → [FIND](#find) first.
+5. `get/read/open/use <target>` always counts as retrieval intent.
 
-When a short word fails alias resolution, treat it as a search keyword rather than an error. Do not ask the user to clarify before trying both paths.
-
-`get pack` — by `id`, or by `alias` with `type: context`. Default returns outline only; pass `--full` for all blocks, or `--block-id` to load a single block.
+`get pack` — by `id`, or by `alias`. Default returns outline only; pass `--full` for all blocks, or `--block-id` to load a single block.
 
 Read the most relevant block first. Continue from there without re-reading history.
 
@@ -239,7 +249,7 @@ Read the most relevant block first. Continue from there without re-reading histo
 
 **Goal:** discover the right pack when the ID is not known.
 
-`search pack` — scan titles only (no full content). Search in this order:
+`search pack` — scan titles only (no full content). Use this for natural-language discovery requests and multi-keyword topic phrases. Search in this order:
 
 1. `type: context`, `query: <topic>`, `filter: { visibility: ["private"] }`
 2. `type: context`, `query: <topic>`, `filter: { like: "liked" }`
@@ -257,7 +267,15 @@ For filter keys, sort options, and search recipes, see [Search & Discovery](./re
 
 ### ID or alias known
 
-`get pack` → `upsert pack` with `id`, updated `"blocks[]"` (include block `"id"` to update existing blocks in place), and updated `"content"` if the top-level intro changed.
+Always fetch before writing.
+
+`get pack` → inspect current blocks → `upsert pack` with `id`, updated `"blocks[]"`, and updated `"content"` if needed.
+
+For `update <alias> based on this conversation`:
+
+- merge new context into the right existing blocks
+- rewrite blocks coherently instead of appending raw notes
+- add a new block only for a distinct new topic
 
 ### ID unknown
 

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -59,6 +59,16 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 
 Use the two-step scan-then-fetch pattern to avoid pulling full content from packs you don't need.
 
+## Query vs Alias
+
+Use `get pack --alias` first for alias-shaped targets.
+
+- Good alias candidates: `@handle/name`, `weekly-handoff`, `frontend_notes`
+- Short phrases can still be aliases: try alias first unless the input is obviously a search query
+- Search-first inputs: `what context do I have for onboarding`, `find onboarding notes`, longer descriptive requests
+- `get/read/open <target>` → try alias or ID first, then `search pack --query` if it misses
+- For bare multi-word input, default to `search pack --query` rather than alias resolution.
+
 ### Step 1 — Scan titles
 
 `search pack` always returns outline format (`id`, `title`, brief metadata) — never full content blocks.

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-pack
-description: "Discover, reuse, and release workflow packs in Epismo. Trigger on: 'find a workflow', 'new workflow', 'create workflow', 'capture pattern', 'adapt a workflow', 'reuse this pattern', 'update workflow', 'organize steps', 'release this as a workflow', 'publish a workflow', 'deprecate workflow', or any intent to search community workflows or capture a proven execution pattern for reuse."
+description: "Discover, reuse, and release workflow packs in Epismo. Trigger on: 'find a workflow', 'get <id>', 'read <alias>', 'new workflow', 'create workflow', 'capture pattern', 'adapt a workflow', 'reuse this pattern', 'update workflow', 'organize steps', 'release this as a workflow', 'publish a workflow', 'deprecate workflow', or any intent to search community workflows or capture a proven execution pattern for reuse."
 ---
 
 # Workflow Pack
@@ -18,7 +18,7 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | Command                 | Natural language triggers                                             | →                     |
 | ----------------------- | --------------------------------------------------------------------- | --------------------- |
 | `new`                   | create workflow, capture pattern, adapt a pattern, new workflow       | [NEW](#new)           |
-| `use <id\|alias>`       | load this ID, open alias, load workflow                               | [USE](#use)           |
+| `get <id\|alias>`       | get this ID, load this ID, read alias, open alias, load workflow      | [GET](#get)           |
 | `find <query>`          | find a workflow, search workflows, what workflows do I have           | [FIND](#find)         |
 | `update [<id\|alias>]`  | edit steps, update workflow, modify steps                             | [UPDATE](#update)     |
 | `organize`              | reorganize steps, reorder, clean up workflow                          | [ORGANIZE](#organize) |
@@ -30,7 +30,7 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | Operation      | CLI                                                                                                         | MCP                  |
 | -------------- | ----------------------------------------------------------------------------------------------------------- | -------------------- |
 | `search pack`  | `epismo pack search --type workflow --filter '{...}'`                                                       | `epismo_pack_search` |
-| `get pack`     | `epismo pack get --id <id> [--full] [--step-id <ids>]`<br>`epismo pack get --type workflow --alias <alias>` | `epismo_pack_get`    |
+| `get pack`     | `epismo pack get --id <id> [--full] [--step-id <ids>]`<br>`epismo pack get --alias <alias>` | `epismo_pack_get`    |
 | `upsert pack`  | `epismo pack upsert --input '<json>'`                                                                       | `epismo_pack_upsert` |
 | `delete pack`  | `epismo pack delete --id <id>`                                                                              | `epismo_pack_delete` |
 | `like pack`    | `epismo pack like --id <id> --liked`                                                                        | `epismo_pack_like`   |
@@ -121,25 +121,36 @@ step      <step-id>      <step-title>
 
 ---
 
-## USE
+## GET
 
-**Goal:** load a workflow when the user supplies an ID, alias, or short label.
+**Goal:** fetch a workflow by ID, alias, or explicit read/open target.
+
+### Route intent before resolving
+
+Prefer **alias-first** unless the input is obviously a search query.
+
+| Input pattern | Route | Why |
+| --- | --- | --- |
+| `get ...`, `use ...`, `load ...`, `open ...`, `read ...` | [GET](#get) | Explicit retrieval |
+| `find ...`, `search ...`, `what workflows do I have`, `show workflows` | [FIND](#find) | Explicit discovery |
+| Bare UUID | [GET](#get) | IDs are unambiguous |
+| Bare alias-shaped token | [GET](#get) | Try alias first, then search if it misses |
+| Short ambiguous phrase | [GET](#get) | Try alias first, then search if it misses |
+| Obvious search query, question, or long descriptive phrase | [FIND](#find) | Discovery intent is clearer than alias intent |
 
 ### Resolve the input
 
-| Input looks like    | Try first             | Fallback                                        |
-| ------------------- | --------------------- | ----------------------------------------------- |
-| UUID                | `get pack` by `id`    | —                                               |
-| `@handle/name`      | `get pack` by `alias` | tell user if not found                          |
-| short word / phrase | `get pack` by `alias` | if not found → [FIND](#find) with it as keyword |
-
-Do not ask the user to clarify before trying both paths.
+1. UUID → `get pack --id`.
+2. `@handle/name` or one compact token like `prd-review` → `get pack --alias`; if it misses, run [FIND](#find) with the same text.
+3. Short phrase like `deployment checklist` → try `get pack --alias` first; if it misses, run [FIND](#find).
+4. Question, explicit search wording, or long descriptive text → [FIND](#find) first.
+5. `get/read/open/use <target>` always counts as retrieval intent.
 
 `get pack` — default returns outline only; pass `--full` for all steps, or `--step-id` to load specific steps.
 
 ```bash
 epismo pack get --id <pack-id> --full
-epismo pack get --type workflow --alias <alias> --full
+epismo pack get --alias <alias> --full
 epismo pack get --id <pack-id> --step-id <step-id-1>,<step-id-2>
 ```
 
@@ -149,7 +160,7 @@ epismo pack get --id <pack-id> --step-id <step-id-1>,<step-id-2>
 
 **Goal:** discover the right workflow when the ID is not known.
 
-`search pack` — scan titles only (no step content). Search in this order:
+`search pack` — scan titles only (no step content). Use this for natural-language discovery requests and multi-keyword topic phrases. Search in this order:
 
 1. `type: workflow`, `query: <topic>`, `filter: { visibility: ["private"] }`
 2. `type: workflow`, `query: <topic>`, `filter: { like: "liked" }`
@@ -167,7 +178,15 @@ For filter keys, sort options, and search recipes, see [Search & Discovery](./re
 
 ### ID or alias known
 
-`get pack` → `upsert pack` with `id` and updated `steps` or fields.
+Always fetch before writing.
+
+`get pack` → inspect current steps and metadata → `upsert pack` with `id` and updated `steps` or fields.
+
+For `update <alias> based on this conversation`:
+
+- modify the steps where the new guidance belongs
+- add new steps only for new execution work
+- keep `dependsOn`, ownership, and ordering coherent
 
 ### ID unknown
 

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -48,6 +48,16 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 
 Use the two-step scan-then-fetch pattern to avoid loading full workflow content before you know the candidate is relevant.
 
+## Query vs Alias
+
+Use `get pack --alias` first for alias-shaped targets.
+
+- Good alias candidates: `@handle/name`, `prd-review`, `incident_postmortem`
+- Short phrases can still be aliases: try alias first unless the input is obviously a search query
+- Search-first inputs: `what workflows do I have for release`, `find release workflow`, longer descriptive requests
+- `get/read/open <target>` → try alias or ID first, then `search pack --query` if it misses
+- For bare multi-word input, default to `search pack --query` rather than alias resolution.
+
 ### Step 1 — Scan titles
 
 ```bash


### PR DESCRIPTION
- Rename USE → GET in context-pack and workflow-pack
- Remove --type flag from get pack --alias calls
- Expand GET route intent table with explicit routing rules
- Add "Always fetch before writing" to UPDATE sections
- Add Query vs Alias section to search.md references
- Update skill descriptions to include 'get <id>' and 'read <alias>' triggers