### PR TITLE
Update alias syntax to use @-prefix convention

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -36,10 +36,10 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 | `update pack`  | `epismo pack update --id <id> --input '<json>'`                                             | `epismo_pack_update` |
 | `delete pack`  | `epismo pack delete --id <id>`                                                              | `epismo_pack_delete` |
 | `like pack`    | `epismo pack like --id <id> --liked`                                                        | `epismo_pack_like`   |
-| `upsert alias` | `epismo alias upsert --type context --id <id> --alias <name>`                               | —                    |
+| `upsert alias` | `epismo alias upsert --type context --id <id> --alias <@name>`                              | —                    |
 | `get alias`    | `epismo alias get --alias <name>`                                                           | —                    |
 | `list aliases` | `epismo alias list --type context`                                                          | —                    |
-| `delete alias` | `epismo alias delete --alias <name>`                                                        | —                    |
+| `delete alias` | `epismo alias delete --alias <@name>`                                                       | —                    |
 
 ---
 
@@ -77,8 +77,17 @@ The pack should read well from scratch at any point. Do not leave stale or contr
   "id": "<existing-id>",
   "content": "<top-level summary or intro — does not include block content>",
   "blocks": [
-    { "op": "update", "id": "<existing-block-id>", "title": "<block-title>", "content": "<updated block content>" },
-    { "op": "add", "title": "<new-block-title>", "content": "<new block content>" }
+    {
+      "op": "update",
+      "id": "<existing-block-id>",
+      "title": "<block-title>",
+      "content": "<updated block content>"
+    },
+    {
+      "op": "add",
+      "title": "<new-block-title>",
+      "content": "<new block content>"
+    }
   ]
 }
 ```
@@ -149,9 +158,9 @@ Default `private`. Use [PUBLISH](#publish) to go public.
 - Blocks are passed as a separate `"blocks[]"` array — **not** embedded in the top-level `"content"` string.
 - `"content"` at the top level is a brief intro only. All substantive content belongs in blocks.
 
-| Who needs it | `visibility` | Access target                    |
-| ------------ | ------------ | -------------------------------- |
-| Just me      | `"private"`  | omit `targets`                   |
+| Who needs it | `visibility` | Access target                   |
+| ------------ | ------------ | ------------------------------- |
+| Just me      | `"private"`  | omit `targets`                  |
 | My team      | `"private"`  | `targets.projectIds=["pj_xxx"]` |
 
 ```
@@ -232,7 +241,7 @@ Prefer **alias-first** unless the input is obviously a search query.
 ### Resolve the input
 
 1. UUID → `get pack --id`.
-2. `@handle/name` or one compact token like `weekly-handoff` → `get pack --alias`; if it misses, run [FIND](#find) with the same text.
+2. `@alias`, `@handle/name`, or one compact token like `weekly-handoff` → `get pack --alias`; if it misses, run [FIND](#find) with the same text.
 3. Short phrase like `auth refactor handoff` → try `get pack --alias` first; if it misses, run [FIND](#find).
 4. Question, explicit search wording, or long descriptive text → [FIND](#find) first.
 5. `get/read/open/use <target>` always counts as retrieval intent.

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -9,11 +9,11 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 
 ## Surface Resolution
 
-| Operation     | CLI command                          | Key flags                                                |
-| ------------- | ------------------------------------ | -------------------------------------------------------- |
-| `search pack` | `epismo pack search --type context`  | `--query <keywords>` `--filter '{...}'` `--project-ids`  |
-| `get pack`    | `epismo pack get --id <id>`          | `[--full]` `[--block-id <block-id>]`                     |
-| `like pack`   | `epismo pack like --id <id> --liked` | `--no-liked` to remove                                   |
+| Operation     | CLI command                          | Key flags                                               |
+| ------------- | ------------------------------------ | ------------------------------------------------------- |
+| `search pack` | `epismo pack search --type context`  | `--query <keywords>` `--filter '{...}'` `--project-ids` |
+| `get pack`    | `epismo pack get --id <id>`          | `[--full]` `[--block-id <block-id>]`                    |
+| `like pack`   | `epismo pack like --id <id> --liked` | `--no-liked` to remove                                  |
 
 ## Quick Reference
 
@@ -64,7 +64,7 @@ Use the two-step scan-then-fetch pattern to avoid pulling full content from pack
 
 Use `get pack --alias` first for alias-shaped targets.
 
-- Good alias candidates: `@handle/name`, `weekly-handoff`, `frontend_notes`
+- Good alias candidates: `@alias`, `@handle/name`, `weekly-handoff`, `frontend_notes`
 - Short phrases can still be aliases: try alias first unless the input is obviously a search query
 - Search-first inputs: `what context do I have for onboarding`, `find onboarding notes`, longer descriptive requests
 - `get/read/open <target>` → try alias or ID first, then `search pack --query` if it misses

--- a/skills/epismo-basics/references/pack-alias.md
+++ b/skills/epismo-basics/references/pack-alias.md
@@ -6,13 +6,14 @@ An alias is a short, human-readable name that resolves to a pack ID. Use it anyw
 
 ## Alias Format
 
-| Format              | Where accepted            | Resolves to          |
-| ------------------- | ------------------------- | -------------------- |
-| `myproject`         | upsert, get, list, delete | Your own alias       |
-| `@handle/myproject` | get only                  | Another user's alias |
+| Format              | Where accepted            | Resolves to              |
+| ------------------- | ------------------------- | ------------------------ |
+| `myproject`         | upsert, get, list, delete | Your own alias           |
+| `@myproject`        | upsert, get, delete       | Your own alias reference |
+| `@handle/myproject` | get only                  | Another user's alias     |
 
-- **upsert / delete** — bare name only (`myproject`). The namespace is always your own account.
-- **get** — accepts both forms to support referencing others' aliases.
+- **upsert / delete** — accept `myproject` or `@myproject`; both are stored as `myproject`. The namespace is always your own account.
+- **get** — prefer `@myproject` for your own alias and `@handle/myproject` for another user's alias. Bare aliases are accepted for compatibility.
 
 ## Access Options
 
@@ -26,8 +27,8 @@ An alias is a short, human-readable name that resolves to a pack ID. Use it anyw
 #### Upsert (create or update)
 
 ```bash
-epismo alias upsert --type workflow --id <id> --alias myproject
-epismo alias upsert --type context  --id <id> --alias mycontext
+epismo alias upsert --type workflow --id <id> --alias @myproject
+epismo alias upsert --type context  --id <id> --alias @mycontext
 ```
 
 You can only alias your own packs. The command verifies ownership before writing.
@@ -35,9 +36,9 @@ You can only alias your own packs. The command verifies ownership before writing
 #### Get (resolve a single alias)
 
 ```bash
-epismo alias get --alias myproject
+epismo alias get --alias @myproject
 epismo alias get --alias @handle/myproject    # another user's alias
-epismo alias get --alias myproject --type workflow
+epismo alias get --alias @myproject --type workflow
 ```
 
 Returns `id`, `type`, `accountId`, and `alias`.
@@ -55,7 +56,7 @@ epismo alias list --type context
 #### Delete
 
 ```bash
-epismo alias delete --alias myproject
+epismo alias delete --alias @myproject
 ```
 
 #### Use an alias to fetch a pack
@@ -63,9 +64,9 @@ epismo alias delete --alias myproject
 `pack get` accepts `--alias` as an alternative to `--id`:
 
 ```bash
-epismo pack get --alias myproject
+epismo pack get --alias @myproject
 epismo pack get --alias @handle/myproject
-epismo pack get --alias mycontext --block-id <block-id>
+epismo pack get --alias @mycontext --block-id <block-id>
 ```
 
 `--id` and `--alias` are mutually exclusive; one is required.
@@ -82,7 +83,7 @@ epismo pack get --alias mycontext --block-id <block-id>
 curl -sX PUT https://api.epismo.ai/v1/aliases \
   -H "Authorization: Bearer <ACCESS_TOKEN>" \
   -H "Content-Type: application/json" \
-  -d '{"type":"workflow","id":"<pack-id>","alias":"myproject"}'
+  -d '{"type":"workflow","id":"<pack-id>","alias":"@myproject"}'
 ```
 
 #### List
@@ -96,7 +97,7 @@ curl -sX GET https://api.epismo.ai/v1/aliases \
 
 ```bash
 # Own alias
-curl -sX GET "https://api.epismo.ai/v1/aliases?alias=myproject" \
+curl -sX GET "https://api.epismo.ai/v1/aliases?alias=%40myproject" \
   -H "Authorization: Bearer <ACCESS_TOKEN>"
 
 # Another user's alias
@@ -104,21 +105,21 @@ curl -sX GET "https://api.epismo.ai/v1/aliases?alias=%40epismo%2Fmyproject" \
   -H "Authorization: Bearer <ACCESS_TOKEN>"
 
 # With type filter
-curl -sX GET "https://api.epismo.ai/v1/aliases?alias=myproject&type=workflow" \
+curl -sX GET "https://api.epismo.ai/v1/aliases?alias=%40myproject&type=workflow" \
   -H "Authorization: Bearer <ACCESS_TOKEN>"
 ```
 
 #### Delete
 
 ```bash
-curl -sX DELETE "https://api.epismo.ai/v1/aliases/myproject" \
+curl -sX DELETE "https://api.epismo.ai/v1/aliases/%40myproject" \
   -H "Authorization: Bearer <ACCESS_TOKEN>"
 ```
 
 #### Use an alias to fetch a pack
 
 ```bash
-curl -sX GET "https://api.epismo.ai/v1/packs?alias=myproject" \
+curl -sX GET "https://api.epismo.ai/v1/packs?alias=%40myproject" \
   -H "Authorization: Bearer <ACCESS_TOKEN>"
 ```
 

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -35,10 +35,10 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | `update pack`  | `epismo pack update --id <id> --input '<json>'`                                             | `epismo_pack_update` |
 | `delete pack`  | `epismo pack delete --id <id>`                                                              | `epismo_pack_delete` |
 | `like pack`    | `epismo pack like --id <id> --liked`                                                        | `epismo_pack_like`   |
-| `upsert alias` | `epismo alias upsert --type workflow --id <id> --alias <name>`                              | —                    |
+| `upsert alias` | `epismo alias upsert --type workflow --id <id> --alias <@name>`                             | —                    |
 | `get alias`    | `epismo alias get --alias <name>`                                                           | —                    |
 | `list aliases` | `epismo alias list --type workflow`                                                         | —                    |
-| `delete alias` | `epismo alias delete --alias <name>`                                                        | —                    |
+| `delete alias` | `epismo alias delete --alias <@name>`                                                       | —                    |
 
 ---
 
@@ -125,9 +125,9 @@ Default `private`. Use [RELEASE](#release) to publish publicly.
 }
 ```
 
-| Who needs it | `visibility` | Access target                    |
-| ------------ | ------------ | -------------------------------- |
-| Just me      | `"private"`  | omit `targets`                   |
+| Who needs it | `visibility` | Access target                   |
+| ------------ | ------------ | ------------------------------- |
+| Just me      | `"private"`  | omit `targets`                  |
 | My team      | `"private"`  | `targets.projectIds=["pj_xxx"]` |
 
 ```
@@ -157,7 +157,7 @@ Prefer **alias-first** unless the input is obviously a search query.
 ### Resolve the input
 
 1. UUID → `get pack --id`.
-2. `@handle/name` or one compact token like `prd-review` → `get pack --alias`; if it misses, run [FIND](#find) with the same text.
+2. `@alias`, `@handle/name`, or one compact token like `prd-review` → `get pack --alias`; if it misses, run [FIND](#find) with the same text.
 3. Short phrase like `deployment checklist` → try `get pack --alias` first; if it misses, run [FIND](#find).
 4. Question, explicit search wording, or long descriptive text → [FIND](#find) first.
 5. `get/read/open/use <target>` always counts as retrieval intent.

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -8,14 +8,14 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 
 ## Operations
 
-| Operation      | CLI command                          | Key flags                                        |
-| -------------- | ------------------------------------ | ------------------------------------------------ |
-| `search pack`  | `epismo pack search --type workflow` | `--query <keywords>` `--filter '{...}'` `--project-ids` |
-| `get pack`     | `epismo pack get --id <id>`          | `[--full]` `[--step-id <step-id-1>,<step-id-2>]` |
-| `create pack`  | `epismo pack create`                 | `--input @pack.json` or `--project-ids <ids>`    |
-| `update pack`  | `epismo pack update --id <id>`       | `--input @changes.json` or `--project-ids <ids>` |
-| `delete pack`  | `epismo pack delete --id <id>`       | —                                                |
-| `like pack`    | `epismo pack like --id <id>`         | `--liked` / `--no-liked`                         |
+| Operation     | CLI command                          | Key flags                                               |
+| ------------- | ------------------------------------ | ------------------------------------------------------- |
+| `search pack` | `epismo pack search --type workflow` | `--query <keywords>` `--filter '{...}'` `--project-ids` |
+| `get pack`    | `epismo pack get --id <id>`          | `[--full]` `[--step-id <step-id-1>,<step-id-2>]`        |
+| `create pack` | `epismo pack create`                 | `--input @pack.json` or `--project-ids <ids>`           |
+| `update pack` | `epismo pack update --id <id>`       | `--input @changes.json` or `--project-ids <ids>`        |
+| `delete pack` | `epismo pack delete --id <id>`       | —                                                       |
+| `like pack`   | `epismo pack like --id <id>`         | `--liked` / `--no-liked`                                |
 
 ## Quick Reference
 
@@ -54,7 +54,7 @@ Use the two-step scan-then-fetch pattern to avoid loading full workflow content 
 
 Use `get pack --alias` first for alias-shaped targets.
 
-- Good alias candidates: `@handle/name`, `prd-review`, `incident_postmortem`
+- Good alias candidates: `@alias`, `@handle/name`, `prd-review`, `incident_postmortem`
 - Short phrases can still be aliases: try alias first unless the input is obviously a search query
 - Search-first inputs: `what workflows do I have for release`, `find release workflow`, longer descriptive requests
 - `get/read/open <target>` → try alias or ID first, then `search pack --query` if it misses


### PR DESCRIPTION
Standardize alias references across context-pack, workflow-pack, and epismo-basics skills to use `@name` prefix for own aliases and `@handle/name` for cross-account aliases, matching the canonical alias format in CLI and API examples.