### PR TITLE
Update reuse scan guidance and document credit purchase minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Skills solve this by packaging proven operational patterns into portable instruc
 Tell your agent:
 
 ```
-Set up Epismo access and load the Skills from https://raw.githubusercontent.com/epismoai/skills/main/README.md.
+Set up Epismo access and load the Skills from github.com/epismoai/skills.
 ```
 
 The agent will read this page and complete the steps. Or follow manually:

--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -256,11 +256,11 @@ Read the most relevant block first. Continue from there without re-reading histo
 
 **Goal:** discover the right pack when the ID is not known.
 
-`search pack` — scan titles only (no full content). Use this for natural-language discovery requests and multi-keyword topic phrases. Search in this order:
+`search pack` — scan titles only (no full content). Use this for natural-language discovery requests and multi-keyword topic phrases. Search private and public scopes for the same topic, then compare results before fetching full content:
 
 1. `type: context`, `query: <topic>`, `filter: { visibility: ["private"] }`
-2. `type: context`, `query: <topic>`, `filter: { like: "liked" }`
-3. `type: context`, `query: <topic>`, `filter: { visibility: ["public"] }`
+2. `type: context`, `query: <topic>`, `filter: { visibility: ["public"] }`
+3. `type: context`, `query: <topic>`, `filter: { like: "liked" }`
 
 Present the title list; if the match is clear, `get pack` immediately.
 

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -178,11 +178,11 @@ Look for titles containing "Handoff" or your name in the results.
 
 ### Reuse scan before creating a new pack
 
-Search private packs first, then liked, then public — to avoid duplicating something that already exists.
+Search private and public packs for the same topic, then compare candidates before fetching full content. Check liked packs as a quality signal or fallback.
 
 1. `visibility=["private"]` + `query=<topic>`
-2. `like="liked"` + `query=<topic>`
-3. `visibility=["public"]` + `query=<topic>`
+2. `visibility=["public"]` + `query=<topic>`
+3. `like="liked"` + `query=<topic>`
 
 If a close match is found, prefer `get pack` over creating a new one.
 

--- a/skills/epismo-basics/SKILL.md
+++ b/skills/epismo-basics/SKILL.md
@@ -150,13 +150,13 @@ epismo pack get --id <id> --block-id <block-id>
 epismo pack get --id <id> --step-id <step-id-1>,<step-id-2>
 ```
 
-## Pack Reuse Scan Order
+## Pack Reuse Scan
 
-Before creating any new pack, scan in this order to avoid duplicating something that already exists:
+Before creating any new pack, scan private and public candidates for the same topic so local work and community patterns can be compared directly:
 
-1. `visibility=["private"]` + `query=<topic>` — your own packs first
-2. `like="liked"` + `query=<topic>` — packs you bookmarked
-3. `visibility=["public"]` + `query=<topic>` — community packs
+1. `visibility=["private"]` + `query=<topic>` — your own or workspace-scoped packs
+2. `visibility=["public"]` + `query=<topic>` — community packs for the same topic
+3. `like="liked"` + `query=<topic>` — bookmarked packs as a quality signal or fallback
 
 If a close match is found, prefer `get pack` over creating new.
 

--- a/skills/epismo-basics/references/credit-purchase.md
+++ b/skills/epismo-basics/references/credit-purchase.md
@@ -4,6 +4,8 @@ When an operation returns `Payment Required: Insufficient credits`, check the cu
 
 **Pricing: 1 credit = $0.01**
 
+**Minimum purchase: 500 credits ($5.00) total per checkout**
+
 ## Access Options
 
 - **CLI** — preferred when operating interactively. Run `epismo login` to authenticate.
@@ -27,7 +29,7 @@ epismo credit balance
 #### Step 3. Purchase Credits (Create Stripe Checkout)
 
 ```bash
-epismo credit checkout --allocations '[{"userId":"<USER_ID>","quantity":10}]'
+epismo credit checkout --allocations '[{"userId":"<USER_ID>","quantity":500}]'
 epismo credit checkout --input @checkout.json
 ```
 
@@ -85,7 +87,7 @@ Call `POST /v1/credits` with `Authorization: Bearer <ACCESS_TOKEN>`.
 - `workspaceId` (optional): target workspace. If provided, the caller must belong to that workspace.
 - `allocations`: recipients and quantities.
 - `userId`: recipient user ID.
-- `quantity`: number of credits (integer).
+- `quantity`: number of credits (integer). The allocation total must be at least 500 credits.
 
 ```bash
 curl -sX POST https://api.epismo.ai/v1/credits \

--- a/skills/project-tracking/references/runbook.md
+++ b/skills/project-tracking/references/runbook.md
@@ -158,7 +158,7 @@ Exit: coordinated items created with ownership contracts and dependency links.
 Readiness checks:
 
 - Current goals and tasks reviewed.
-- Reuse check completed against workflows (`private` → `liked` → `public`).
+- Reuse check completed against both private and public workflows, with liked workflows checked as a quality signal or fallback.
 - Why reuse is insufficient is explicit.
 - Project scope confirmed.
 

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -7,7 +7,7 @@ description: "Discover, reuse, and release workflow packs in Epismo. Trigger on:
 
 Discover, adapt, and release reusable workflow packs in Epismo — from finding a community pattern to publishing a proven execution structure.
 
-**Core principle: reuse before creating. Search private → liked → public before building anything new.**
+**Core principle: reuse before creating. Search private and public candidates together, then compare with liked/bookmarked workflows before building anything new.**
 
 > For connection setup, surface conventions, scope model, share URL resolution, and error handling, see [Epismo Basics](../epismo-basics/SKILL.md).
 > For task/goal tracking, see [Project Tracking](../project-tracking/SKILL.md).
@@ -48,17 +48,17 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 
 ### Step 1 — Reuse scan
 
-Infer 2–4 topic keywords from the user's intent. Search in this order:
+Infer 2–4 topic keywords from the user's intent. Search private and public scopes together so local patterns and community patterns can be compared before choosing a base.
 
 ```bash
-# 1. Your own private workflows
+# Private workflows in the active workspace
 epismo pack search --type workflow --query "<topic>" --filter '{"visibility":["private"]}'
 
-# 2. Workflows you bookmarked
-epismo pack search --type workflow --filter '{"like":"liked"}'
-
-# 3. Community public workflows
+# Public community workflows
 epismo pack search --type workflow --query "<topic>" --filter '{"visibility":["public"]}'
+
+# Bookmarked workflows, useful as a quality signal or fallback
+epismo pack search --type workflow --query "<topic>" --filter '{"like":"liked"}'
 ```
 
 | Result        | Action                                                                     |
@@ -176,11 +176,11 @@ epismo pack get --id <pack-id> --step-id <step-id-1>,<step-id-2>
 
 **Goal:** discover the right workflow when the ID is not known.
 
-`search pack` — scan titles only (no step content). Use this for natural-language discovery requests and multi-keyword topic phrases. Search in this order:
+`search pack` — scan titles only (no step content). Use this for natural-language discovery requests and multi-keyword topic phrases. Search private and public scopes for the same topic, then compare results before fetching full content:
 
 1. `type: workflow`, `query: <topic>`, `filter: { visibility: ["private"] }`
-2. `type: workflow`, `query: <topic>`, `filter: { like: "liked" }`
-3. `type: workflow`, `query: <topic>`, `filter: { visibility: ["public"] }`
+2. `type: workflow`, `query: <topic>`, `filter: { visibility: ["public"] }`
+3. `type: workflow`, `query: <topic>`, `filter: { like: "liked" }`
 
 Present the title list; if the match is clear, `get pack` immediately.
 
@@ -206,7 +206,7 @@ For `update <alias> based on this conversation`:
 
 ### ID unknown
 
-1. `search pack` — `type: workflow`, `query: <inferred topic>`, `filter: { visibility: ["private"] }`
+1. `search pack` — `type: workflow`, `query: <inferred topic>`, run both `filter: { visibility: ["private"] }` and `filter: { visibility: ["public"] }`
 2. **One clear match** → fetch and update without asking.
 3. **Multiple candidates** → show titles and IDs, ask the user to pick.
 4. **No match** → fall back to [NEW](#new).

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -80,7 +80,7 @@ epismo pack get --id <pack-id> --step-id <step-id-1>,<step-id-2>
 
 ## Reuse Scan
 
-Search in this order to avoid rebuilding something that already exists — see [Epismo Basics — Pack Reuse Scan Order](../../epismo-basics/SKILL.md#pack-reuse-scan-order).
+Search private and public scopes for the same topic, then compare candidates before fetching full content — see [Epismo Basics — Pack Reuse Scan](../../epismo-basics/SKILL.md#pack-reuse-scan).
 
 ## Search Recipes
 


### PR DESCRIPTION
## Summary
- Reframe pack reuse scan across context-pack, workflow-pack, epismo-basics, and project-tracking: compare private and public candidates together for the same topic, with liked packs as a quality signal or fallback (was: strict private → liked → public).
- Document the 500-credit ($5) minimum per Stripe checkout in epismo-basics/references/credit-purchase.md and update the example allocation from 10 → 500.
- Simplify the README setup URL to `github.com/epismoai/skills`.

## Test plan
- [ ] Skim each updated SKILL.md / reference to confirm wording is consistent across packs
- [ ] Verify the credit-purchase example command is copy-pasteable

🤖 Generated with [Claude Code](https://claude.com/claude-code)