### PR TITLE
Migrate ACL model from targets to scope/sharedWith

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -158,10 +158,11 @@ Default `private`. Use [PUBLISH](#publish) to go public.
 - Blocks are passed as a separate `"blocks[]"` array — **not** embedded in the top-level `"content"` string.
 - `"content"` at the top level is a brief intro only. All substantive content belongs in blocks.
 
-| Who needs it | `visibility` | Access target                   |
-| ------------ | ------------ | ------------------------------- |
-| Just me      | `"private"`  | omit `targets`                  |
-| My team      | `"private"`  | `targets.projectIds=["pj_xxx"]` |
+| Who needs it    | `visibility` | Scope / share                                    |
+| --------------- | ------------ | ------------------------------------------------ |
+| Just me         | `"private"`  | `scope: { type: "personal" }`                    |
+| My team         | `"private"`  | `scope: { type: "projects", ids: ["pj_xxx"] }`   |
+| Specific people | `"private"`  | any `scope` + `sharedWith: { userIds / emails }` |
 
 ```
 context  <context-id>  <context-title>

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -11,7 +11,7 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 
 | Operation     | CLI command                         | Key flags                                               |
 | ------------- | ----------------------------------- | ------------------------------------------------------- |
-| `search pack` | `epismo pack search --type context` | `--query <keywords>` `--filter '{...}'` `--project-ids` |
+| `search pack` | `epismo pack search --type context` | `--query <keywords>` `--filter '{...}'` `--projects`    |
 | `get pack`    | `epismo pack get <id>`              | `[--full]` `[--block-id <block-id>]`                    |
 | `like pack`   | `epismo pack like <id> --liked`     | `--no-liked` to remove                                  |
 
@@ -34,8 +34,8 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 2. `search pack --type context` returns both private (yours) and public packs unless filtered.
 3. `filter.visibility=["private"]` returns only your private packs.
 4. `filter.visibility=["public"]` returns all public packs discoverable from the active workspace.
-5. `targets.projectIds=["<project-id>"]` narrows private search scope to that project. In CLI, pass `--project-ids <ids>`.
-6. `targets.self` controls whether search includes packs that target the current user directly. In CLI, pass `--self false` to exclude them.
+5. `scopes=[{type:"projects", ids:["<project-id>"]}]` narrows private search scope to that project. In CLI, pass `--projects <ids>`.
+6. Add `{type:"personal"}` to `scopes` to include packs that target the current user directly. In CLI, pass `--personal`.
 7. `query` runs a semantic / keyword search on title and content. Keep it to 2–6 domain keywords.
 8. Omitting all filters returns the most recently updated packs in the active workspace.
 
@@ -158,9 +158,7 @@ Look for titles containing "Handoff" or your name in the results.
 ```json
 {
   "type": "context",
-  "targets": {
-    "projectIds": ["pj_123"]
-  },
+  "scopes": [{ "type": "projects", "ids": ["pj_123"] }],
   "filter": {
     "visibility": ["private"]
   }

--- a/skills/context-pack/references/visibility.md
+++ b/skills/context-pack/references/visibility.md
@@ -60,16 +60,23 @@ Set `category` on public packs to improve discoverability. On private packs it i
 
 Choose the most specific category that fits. If two categories apply equally, prefer the one the intended audience would search in.
 
-## Project Scoping
+## Scope & Sharing
 
-`targets.projectIds[]` attaches a private pack to one or more workspace projects. This controls which project members can discover the pack in project-scoped searches.
+Private context packs use `scope` plus optional `sharedWith` to control who can find and write to them.
+
+- `scope: { type: "personal" }` — the pack lives in the caller's personal space.
+- `scope: { type: "projects", ids: [...] }` — attaches the pack to one or more workspace projects. Project members can discover it in project-scoped searches.
+- `sharedWith: { userIds?: [...], emails?: [...] }` — optional, grants access to specific people in addition to the chosen `scope`. Works with both `personal` and `projects` scope.
 
 **Rules:**
 
-- `targets.projectIds[]` is valid **only** when `visibility="private"`.
-- For public packs, omit `targets` — public packs are workspace-level and globally discoverable regardless of project.
-- A pack can belong to multiple projects simultaneously.
-- Changing `targets.projectIds[]` on an existing pack is a safe partial update — it does not change content or visibility.
+- `scope` is required on create. There is no implicit personal fallback — omitting it returns a validation error.
+- On update, omit `scope`/`sharedWith` to preserve existing ACL bits; passing them replaces.
+- `scope.projects.ids` must be non-empty and a subset of the caller's accessible projects (`references.projects`).
+- `scope: { type: "projects" }` is only valid in a workspace context.
+- Switching an item with hidden project shares to `scope: { type: "personal" }` errors out.
+- `scope`/`sharedWith` apply only when `visibility="private"`. For public packs, omit them — public packs are workspace-level and globally discoverable regardless of project.
+- CLI flags: `--personal`, `--projects <id...>`, `--share-with <userIdOrEmail...>` (values containing `@` are treated as emails).
 
 ## Sharing a Context Pack
 
@@ -117,15 +124,15 @@ Liked packs appear in search results filtered by `like="liked"` and surface high
 
 Some visibility and lifecycle actions require **explicit user approval** before writing. Do not proceed without it.
 
-| Action                                                | Approval required? | Why                                               |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------- |
-| First-time public publication (`visibility="public"`) | **Yes**            | Irreversible — content becomes globally visible   |
-| Changing existing pack from `private` to `public`     | **Yes**            | Visibility change may expose internal information |
-| Deleting a pack (`delete pack`)                       | **Yes**            | Irreversible if not in trash/recovery             |
-| Overwriting another owner's pack                      | **Yes**            | Affects content the user does not own             |
-| Creating or updating a private pack                   | No                 | Low risk, reversible                              |
-| Changing `targets.projectIds[]` on an existing private pack | No                 | Scoping change only                               |
-| Liking or un-liking a pack                            | No                 | Reversible signal, no content change              |
+| Action                                                       | Approval required? | Why                                               |
+| ------------------------------------------------------------ | ------------------ | ------------------------------------------------- |
+| First-time public publication (`visibility="public"`)        | **Yes**            | Irreversible — content becomes globally visible   |
+| Changing existing pack from `private` to `public`            | **Yes**            | Visibility change may expose internal information |
+| Deleting a pack (`delete pack`)                              | **Yes**            | Irreversible if not in trash/recovery             |
+| Overwriting another owner's pack                             | **Yes**            | Affects content the user does not own             |
+| Creating or updating a private pack                          | No                 | Low risk, reversible                              |
+| Changing `scope` or `sharedWith` on an existing private pack | No                 | Scoping change only                               |
+| Liking or un-liking a pack                                   | No                 | Reversible signal, no content change              |
 
 **How to obtain approval:** state the intended action, the pack title, and the visibility setting. Wait for an explicit "yes", "go ahead", or equivalent confirmation before writing.
 
@@ -133,12 +140,12 @@ Some visibility and lifecycle actions require **explicit user approval** before 
 
 Use this table to decide visibility and distribution method based on who needs the pack.
 
-| Audience                                     | Visibility               | Distribution method                                                            |
-| -------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------ |
-| Just me, this session                        | `private`                | Read directly via `get pack` in the next session                               |
-| My team in this workspace                    | `private` + `targets.projectIds[]` | Share URL (team members have workspace access)                                 |
-| A specific person (any tool)                 | `private` then share     | Share URL — recipient can view if they have access; use `public` if they don't |
-| Everyone on Epismo                           | `public`                 | Share URL or community search                                                  |
-| External audience (no Epismo account needed) | `public`                 | Share URL — no login required to view                                          |
+| Audience                                     | Visibility                                            | Distribution method                                                            |
+| -------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Just me, this session                        | `private`                                             | Read directly via `get pack` in the next session                               |
+| My team in this workspace                    | `private` + `scope: { type: "projects", ids: [...] }` | Share URL (team members have workspace access)                                 |
+| A specific person (any tool)                 | `private` then share                                  | Share URL — recipient can view if they have access; use `public` if they don't |
+| Everyone on Epismo                           | `public`                                              | Share URL or community search                                                  |
+| External audience (no Epismo account needed) | `public`                                              | Share URL — no login required to view                                          |
 
 If the recipient does not have workspace access and the content is safe to share openly, publish as `public`. If the content must stay private but needs to reach someone outside the workspace, discuss access provisioning with the user — this skill cannot grant workspace access.

--- a/skills/context-pack/templates/content.md
+++ b/skills/context-pack/templates/content.md
@@ -286,8 +286,9 @@ Use this as the smallest safe starting shape. Add optional fields only when need
   "content": "Summary of the Attention Is All You Need paper.",
   "type": "context",
   "visibility": "private",
-  "targets": {
-    "projectIds": ["pj_123"]
+  "scope": {
+    "type": "projects",
+    "ids": ["pj_123"]
   },
   "blocks": [
     {
@@ -336,12 +337,22 @@ Use `update pack` with explicit `op` fields. Omitting `"blocks"` keeps all exist
 {
   "id": "<pack-id>",
   "blocks": [
-    { "op": "update", "id": "b001", "title": "Source", "content": "<updated content>" },
-    { "op": "update", "id": "b002", "title": "Summary", "content": "<updated content>" },
+    {
+      "op": "update",
+      "id": "b001",
+      "title": "Source",
+      "content": "<updated content>"
+    },
+    {
+      "op": "update",
+      "id": "b002",
+      "title": "Summary",
+      "content": "<updated content>"
+    },
     { "op": "add", "title": "New Block", "content": "<new block content>" },
     { "op": "remove", "id": "b003" }
   ]
 }
 ```
 
-> Note: `targets.projectIds[]` is valid only when `visibility="private"`. Omit `targets` for public packs.
+> Note: `scope` is required on create and only applies when `visibility="private"`. Use `scope: { type: "personal" }` for personal packs or `scope: { type: "projects", ids: [...] }` for project-scoped packs. Add optional `sharedWith: { userIds, emails }` to grant access to specific people. Omit `scope`/`sharedWith` for public packs.

--- a/skills/epismo-basics/SKILL.md
+++ b/skills/epismo-basics/SKILL.md
@@ -70,10 +70,11 @@ Workspace selection is CLI-only. All CLI commands resolve workspace automaticall
 ## Scope Model
 
 - `workspace` — top-level access boundary. All operations run within the active workspace.
-- **Search inputs** use `targets`:
-  - `targets.projectIds[]` — narrows private search to specific projects within the active workspace. Omit to use the default private scope; `targets.projectIds: []` explicitly disables project targets.
-  - `targets.self` — include private items that target the current user directly; defaults to `true`.
-  - CLI search flags `--project-ids` and `--self` build the `targets` object.
+- **Search inputs** use additive `scopes`:
+  - `scopes: [{ type: "personal" }]` — search items that target the current user directly.
+  - `scopes: [{ type: "projects", ids: [...] }]` — search items in specific projects.
+  - Combine both scopes to search personal and project items together. Omit `scopes` to use the default search scope.
+  - CLI search flags `--personal` and `--projects` build `scopes`.
 - **Mutation inputs** (pack/track create, update, apply) use `scope` plus optional `sharedWith`:
   - `scope: { type: "personal" }` — write to the caller's personal space.
   - `scope: { type: "projects", ids: [...] }` — write to specific projects. `ids` must be non-empty and a subset of the caller's accessible projects (see `references.projects`). `projects` scope is only valid in a workspace context.

--- a/skills/epismo-basics/SKILL.md
+++ b/skills/epismo-basics/SKILL.md
@@ -70,16 +70,22 @@ Workspace selection is CLI-only. All CLI commands resolve workspace automaticall
 ## Scope Model
 
 - `workspace` — top-level access boundary. All operations run within the active workspace.
-- `targets.projectIds[]` — narrows private search or write access to specific projects within the active workspace.
-- `targets.userIds[]` / `targets.emails[]` — grant private write access to specific people on mutation calls.
-- `targets.self` — for search, include private items that target the current user directly; defaults to `true`.
-- CLI search/write flags such as `--project-ids`, `--user-ids`, `--emails`, and `--self` are convenience flags that build the `targets` object.
-- For search, omitting `targets.projectIds` uses the default private scope for the current context; `targets.projectIds: []` explicitly disables project targets.
+- **Search inputs** use `targets`:
+  - `targets.projectIds[]` — narrows private search to specific projects within the active workspace. Omit to use the default private scope; `targets.projectIds: []` explicitly disables project targets.
+  - `targets.self` — include private items that target the current user directly; defaults to `true`.
+  - CLI search flags `--project-ids` and `--self` build the `targets` object.
+- **Mutation inputs** (pack/track create, update, apply) use `scope` plus optional `sharedWith`:
+  - `scope: { type: "personal" }` — write to the caller's personal space.
+  - `scope: { type: "projects", ids: [...] }` — write to specific projects. `ids` must be non-empty and a subset of the caller's accessible projects (see `references.projects`). `projects` scope is only valid in a workspace context.
+  - `sharedWith: { userIds?: [...], emails?: [...] }` — optional, grants write access to specific people. Works with both `personal` and `projects` scope.
+  - On create, `scope` is required (no implicit personal fallback). On update, omit `scope`/`sharedWith` to preserve existing ACL bits; passing them replaces.
+  - Updating an item that has hidden project shares to `scope: { type: "personal" }` errors out.
+  - CLI mutation flags: `--personal`, `--projects <id...>`, `--share-with <userIdOrEmail...>` (values containing `@` are treated as emails).
 
 When the user refers to "my project", resolve both layers before writing:
 
 1. Active workspace
-2. Target project(s) via `targets.projectIds[]`
+2. Target project(s) via `scope: { type: "projects", ids: [...] }`
 
 ---
 

--- a/skills/project-tracking/references/runbook.md
+++ b/skills/project-tracking/references/runbook.md
@@ -46,8 +46,9 @@ Use these as the smallest safe starting shapes for CLI `--input` payloads. Add o
 {
   "type": "task",
   "title": "Investigate update task error",
-  "targets": {
-    "projectIds": ["pj_123"]
+  "scope": {
+    "type": "projects",
+    "ids": ["pj_123"]
   },
   "task": {
     "status": "todo"
@@ -61,8 +62,9 @@ Use these as the smallest safe starting shapes for CLI `--input` payloads. Add o
 {
   "type": "goal",
   "title": "Release agent task assignment",
-  "targets": {
-    "projectIds": ["pj_123", "pj_456"]
+  "scope": {
+    "type": "projects",
+    "ids": ["pj_123", "pj_456"]
   },
   "goal": {
     "status": "not_started",

--- a/skills/project-tracking/references/runbook.md
+++ b/skills/project-tracking/references/runbook.md
@@ -79,7 +79,7 @@ Use a non-UUID client label (e.g. `"t001"`) as `id` to create a new track. Use a
 
 ```json
 {
-  "projects": ["pj_123"],
+  "scope": { "type": "projects", "ids": ["pj_123"] },
   "updateDrafts": [
     {
       "id": "g001",

--- a/skills/project-tracking/references/search.md
+++ b/skills/project-tracking/references/search.md
@@ -9,10 +9,10 @@ For reusable workflow discovery, see [Workflow Pack — Search & Discovery](../.
 
 | Operation      | CLI command                | Key flags                                              |
 | -------------- | -------------------------- | ------------------------------------------------------ |
-| `search track` | `epismo track search`      | `--type task\|goal` `--filter '{...}'` `--project-ids` |
+| `search track` | `epismo track search`      | `--type task\|goal` `--filter '{...}'` `--projects`    |
 | `get track`    | `epismo track get <id>`    | —                                                      |
-| `create track` | `epismo track create`      | `--input @item.json` or `--project-ids <ids>`          |
-| `update track` | `epismo track update <id>` | `--input @item.json` or `--project-ids <ids>`          |
+| `create track` | `epismo track create`      | `--input @item.json` or `--projects <ids>`             |
+| `update track` | `epismo track update <id>` | `--input @item.json` or `--projects <ids>`             |
 | `delete track` | `epismo track delete <id>` | —                                                      |
 
 ## Quick Reference
@@ -32,9 +32,9 @@ For reusable workflow discovery, see [Workflow Pack — Search & Discovery](../.
 
 1. `workspace` is the top-level access boundary for CLI and MCP calls.
 2. Each workspace can contain multiple projects.
-3. `search track` accepts `targets.projectIds[]` to limit private scope inside the active workspace. In CLI, pass `--project-ids <ids>`.
-4. Omitting `targets.projectIds` uses the default private scope for the current context; `targets.projectIds: []` explicitly disables project targets.
-5. `targets.self` controls whether search includes tracks that target the current user directly. In CLI, pass `--self false` to exclude them.
+3. `search track` accepts additive `scopes[]` to limit private scope inside the active workspace. In CLI, pass `--projects <ids>`, `--personal`, or both.
+4. Omitting `scopes` uses the default search scope for the current context.
+5. Project write scope is `scope:{type:"projects", ids:[...]}`. In CLI, pass `--projects <ids>`.
 6. `search track` requires `type`: `task` or `goal`.
 7. Keep `query` compact when searching related workflow packs through Workflow Pack: 2-6 domain keywords.
 
@@ -114,5 +114,5 @@ These are computed from entity data, not stored as status field values. Use them
 
 ### Release evidence — completed work in a period
 
-- Tasks: `status=["done"]` + `doneAtFrom=<iso8601>` + optional `targets.projectIds=["<project-id>"]`
-- Goals: `status=["completed"]` + `updatedAtFrom=<iso8601>` + optional `targets.projectIds=["<project-id>"]`
+- Tasks: `status=["done"]` + `doneAtFrom=<iso8601>` + optional `scopes=[{type:"projects", ids:["<project-id>"]}]`
+- Goals: `status=["completed"]` + `updatedAtFrom=<iso8601>` + optional `scopes=[{type:"projects", ids:["<project-id>"]}]`

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -125,10 +125,11 @@ Default `private`. Use [RELEASE](#release) to publish publicly.
 }
 ```
 
-| Who needs it | `visibility` | Access target                   |
-| ------------ | ------------ | ------------------------------- |
-| Just me      | `"private"`  | omit `targets`                  |
-| My team      | `"private"`  | `targets.projectIds=["pj_xxx"]` |
+| Who needs it    | `visibility` | Scope / share                                    |
+| --------------- | ------------ | ------------------------------------------------ |
+| Just me         | `"private"`  | `scope: { type: "personal" }`                    |
+| My team         | `"private"`  | `scope: { type: "projects", ids: ["pj_xxx"] }`   |
+| Specific people | `"private"`  | any `scope` + `sharedWith: { userIds / emails }` |
 
 ```
 workflow  <workflow-id>  <workflow-title>

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -88,7 +88,7 @@ Before materializing:
 
 ```bash
 epismo track apply --input '{
-  "projects": ["pj_123"],
+  "scope": { "type": "projects", "ids": ["pj_123"] },
   "updateDrafts": [
     { "id": "s001", "title": "Define scope", "task": { "status": "todo" } },
     { "id": "s002", "title": "Implement", "task": { "status": "todo", "dependsOn": ["s001"] } },

--- a/skills/workflow-pack/references/release.md
+++ b/skills/workflow-pack/references/release.md
@@ -16,7 +16,7 @@ Confirm all six before proceeding:
    - `release` / `update`: quality gate passed per [Workflow Quality](./quality.md).
    - `deprecate`: quality gate not required; deprecation rationale and risk note are sufficient.
 5. **Duplication risk** checked — no clearly superior equivalent already exists.
-6. **Write scope** confirmed: `private` uses confirmed `targets.projectIds[]`; `public` omits `targets`.
+6. **Write scope** confirmed: `private` uses confirmed `scope` (`{ type: "personal" }` or `{ type: "projects", ids: [...] }`) plus optional `sharedWith`; `public` omits `scope`/`sharedWith`.
 
 ## Approval Boundary
 

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -34,7 +34,7 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 2. `search pack --type workflow` returns both private and public workflows unless filtered.
 3. `filter.visibility=["private"]` returns only private workflows in the active workspace.
 4. `filter.visibility=["public"]` returns globally discoverable public workflows.
-5. In `create pack` and `update pack`, `targets.projectIds[]` is valid only when `visibility="private"`. In CLI, pass `--project-ids <ids>`.
+5. In `create pack` and `update pack`, `scope` and `sharedWith` apply only when `visibility="private"`. Use `scope: { type: "personal" }` or `scope: { type: "projects", ids: [...] }`, plus optional `sharedWith: { userIds, emails }`. In CLI, pass `--personal`, `--projects <id...>`, or `--share-with <userIdOrEmail...>`.
 6. `targets.self` controls whether search includes workflows that target the current user directly. In CLI, pass `--self false` to exclude them.
 7. If `visibility` is omitted on pack create/update, default is `private`.
 8. Keep `query` compact: 2-6 domain keywords.

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -10,10 +10,10 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 
 | Operation     | CLI command                          | Key flags                                               |
 | ------------- | ------------------------------------ | ------------------------------------------------------- |
-| `search pack` | `epismo pack search --type workflow` | `--query <keywords>` `--filter '{...}'` `--project-ids` |
+| `search pack` | `epismo pack search --type workflow` | `--query <keywords>` `--filter '{...}'` `--projects`    |
 | `get pack`    | `epismo pack get <id>`               | `[--full]` `[--step-id <step-id-1>,<step-id-2>]`        |
-| `create pack` | `epismo pack create`                 | `--input @pack.json` or `--project-ids <ids>`           |
-| `update pack` | `epismo pack update <id>`            | `--input @changes.json` or `--project-ids <ids>`        |
+| `create pack` | `epismo pack create`                 | `--input @pack.json` or `--projects <ids>`              |
+| `update pack` | `epismo pack update <id>`            | `--input @changes.json` or `--projects <ids>`           |
 | `delete pack` | `epismo pack delete <id>`            | —                                                       |
 | `like pack`   | `epismo pack like <id>`              | `--liked` / `--no-liked`                                |
 
@@ -35,7 +35,7 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 3. `filter.visibility=["private"]` returns only private workflows in the active workspace.
 4. `filter.visibility=["public"]` returns globally discoverable public workflows.
 5. In `create pack` and `update pack`, `scope` and `sharedWith` apply only when `visibility="private"`. Use `scope: { type: "personal" }` or `scope: { type: "projects", ids: [...] }`, plus optional `sharedWith: { userIds, emails }`. In CLI, pass `--personal`, `--projects <id...>`, or `--share-with <userIdOrEmail...>`.
-6. `targets.self` controls whether search includes workflows that target the current user directly. In CLI, pass `--self false` to exclude them.
+6. In search, pass `scopes:[{type:"personal"}, {type:"projects", ids:[...]}]` or use CLI `--personal --projects <ids>`.
 7. If `visibility` is omitted on pack create/update, default is `private`.
 8. Keep `query` compact: 2-6 domain keywords.
 

--- a/skills/workflow-pack/references/visibility.md
+++ b/skills/workflow-pack/references/visibility.md
@@ -48,16 +48,23 @@ Set `category` on public packs to improve discoverability. On private packs it i
 
 Choose the most specific category that fits. If two apply equally, prefer the one the intended audience would search in.
 
-## Project Scoping
+## Scope & Sharing
 
-`targets.projectIds[]` attaches a private workflow pack to one or more workspace projects. This controls which project members can discover the pack in project-scoped searches.
+Private workflow packs use `scope` plus optional `sharedWith` to control who can find and write to them.
+
+- `scope: { type: "personal" }` — the pack lives in the caller's personal space.
+- `scope: { type: "projects", ids: [...] }` — attaches the pack to one or more workspace projects. Project members can discover it in project-scoped searches.
+- `sharedWith: { userIds?: [...], emails?: [...] }` — optional, grants access to specific people in addition to the chosen `scope`. Works with both `personal` and `projects` scope.
 
 **Rules:**
 
-- `targets.projectIds[]` is valid **only** when `visibility="private"`.
-- For public packs, omit `targets` — public packs are workspace-level and globally discoverable.
-- A pack can belong to multiple projects simultaneously.
-- Changing `targets.projectIds[]` on an existing pack is a safe partial update — it does not change content or visibility.
+- `scope` is required on create. There is no implicit personal fallback — omitting it returns a validation error.
+- On update, omit `scope`/`sharedWith` to preserve existing ACL bits; passing them replaces.
+- `scope.projects.ids` must be non-empty and a subset of the caller's accessible projects (`references.projects`).
+- `scope: { type: "projects" }` is only valid in a workspace context.
+- Switching an item with hidden project shares to `scope: { type: "personal" }` errors out.
+- `scope`/`sharedWith` apply only when `visibility="private"`. For public packs, omit them — public packs are workspace-level and globally discoverable.
+- CLI flags: `--personal`, `--projects <id...>`, `--share-with <userIdOrEmail...>` (values containing `@` are treated as emails).
 
 ## Sharing a Workflow Pack
 
@@ -95,14 +102,14 @@ Liked packs surface higher in community discovery and appear in `like="liked"` f
 
 Some actions require **explicit user approval** before writing. Do not proceed without it.
 
-| Action                                                | Approval required? | Why                                              |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------ |
-| First-time public release (`visibility="public"`)     | **Yes**            | Content becomes globally visible                 |
-| Changing existing workflow from `private` to `public` | **Yes**            | May expose internal patterns or team information |
-| Deprecating a workflow                                | **Yes**            | Affects existing users of the pattern            |
-| Overwriting another owner's workflow                  | **Yes**            | Affects content the current user does not own    |
-| Creating or updating a private workflow               | No                 | Low risk, reversible                             |
-| Changing `targets.projectIds[]` on a private workflow | No                 | Scoping change only                              |
-| Liking or un-liking                                   | No                 | Reversible signal, no content change             |
+| Action                                                 | Approval required? | Why                                              |
+| ------------------------------------------------------ | ------------------ | ------------------------------------------------ |
+| First-time public release (`visibility="public"`)      | **Yes**            | Content becomes globally visible                 |
+| Changing existing workflow from `private` to `public`  | **Yes**            | May expose internal patterns or team information |
+| Deprecating a workflow                                 | **Yes**            | Affects existing users of the pattern            |
+| Overwriting another owner's workflow                   | **Yes**            | Affects content the current user does not own    |
+| Creating or updating a private workflow                | No                 | Low risk, reversible                             |
+| Changing `scope` or `sharedWith` on a private workflow | No                 | Scoping change only                              |
+| Liking or un-liking                                    | No                 | Reversible signal, no content change             |
 
 **How to obtain approval:** state the intended action, the workflow title, and the visibility setting. Wait for an explicit "yes" or equivalent before writing.

--- a/skills/workflow-pack/templates/patterns.md
+++ b/skills/workflow-pack/templates/patterns.md
@@ -40,7 +40,7 @@ Use when: comparing candidate workflows and committing to a concrete adaptation 
 - Desired outcome: {what the user wants to achieve}
 - Project context: {team and project constraints}
 - Search plan:
-  - Tracks: {targets.projectIds / status / date filters used}
+  - Tracks: {scopes / status / date filters used}
   - Workflows: {visibility / like / category filters used}
   - Keyword queries: {2-6 domain keywords or none}
 


### PR DESCRIPTION
## Summary
- Switch mutation inputs (pack/track create, update, apply) from `targets.projectIds[]` to `scope` (`personal` or `projects`) plus optional `sharedWith` (`userIds` / `emails`).
- Search inputs continue to use `targets` — the split is now documented explicitly in `epismo-basics`.
- Document new CLI flags `--personal`, `--projects <id...>`, `--share-with <userIdOrEmail...>` (values with `@` are treated as emails).
- Update approval matrices, audience tables, JSON templates, release checklist, and the `create pack` / `update pack` note in `workflow-pack/references/search.md`.

## Test plan
- [ ] Read through `epismo-basics/SKILL.md` Scope Model section and confirm search vs. mutation split is clear.
- [ ] Cross-check `context-pack` and `workflow-pack` visibility references for parallel rules (create required, update preserves, `personal` switch restriction, CLI flags).
- [ ] Verify all create/update JSON templates use `scope` and no stale `targets` remains outside search contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)