### PR TITLE
Standardize CLI/MCP surface docs across skills

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-pack
-description: "Pack, share, and load context using Epismo context packs. Trigger on: 'pack this', 'new pack', 'get <id>', 'read <alias>', 'load my context', 'what context do I have', 'restore session', 'save this context', 'share with my team', 'pack this up', 'hand this off', 'publish this guide', 'organize my packs', or any intent to persist or retrieve knowledge across tools or sessions."
+description: "Pack, share, and load context using Epismo context packs. Trigger on: 'pack this', 'new pack', 'get <id>', 'read <alias>', 'load my context', 'what context do I have', 'restore session', 'save this context', 'share with my team', 'pack this up', 'hand this off', 'publish this guide', 'organize my packs', 'suggest a change to a pack', 'review suggestions', 'resolve a suggestion', or any intent to persist or retrieve knowledge across tools or sessions."
 ---
 
 # Context Pack
@@ -11,35 +11,47 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 
 > For Epismo connection setup, CLI/MCP surface conventions, scope model, share URL resolution, and error handling, see [Epismo Basics](../epismo-basics/SKILL.md).
 
+> For sending and resolving improvement suggestions, see [Suggestions](../epismo-basics/references/suggestions.md).
+
 > **Surface selection:** CLI and MCP connect to the same Epismo service. Use CLI if available; fall back to MCP if not. Never use both in the same session.
 
 ## Commands
 
-| Command                | Natural language triggers                                             | →                     |
-| ---------------------- | --------------------------------------------------------------------- | --------------------- |
-| `pack`                 | pack this, save this, summarize session                               | [PACK](#pack)         |
-| `new`                  | new pack, start fresh, hand off a task, share project status          | [NEW](#new)           |
-| `publish [<id>]`       | publish this, make this public, publish a guide, share with community | [PUBLISH](#publish)   |
-| `get <id\|alias>`      | get this ID, load this ID, restore from ID, read alias, open alias    | [GET](#get)           |
-| `find <query>`         | what context do I have, load my context, search                       | [FIND](#find)         |
-| `update [<id\|alias>]` | edit this pack, update my last pack                                   | [UPDATE](#update)     |
-| `organize`             | reorganize blocks, split this, clean up                               | [ORGANIZE](#organize) |
-| —                      | unclear intent                                                        | Ask once              |
+| Command                | Natural language triggers                                                   | →                     |
+| ---------------------- | --------------------------------------------------------------------------- | --------------------- |
+| `pack`                 | pack this, save this, summarize session                                     | [PACK](#pack)         |
+| `new`                  | new pack, start fresh, hand off a task, share project status                | [NEW](#new)           |
+| `publish [<id>]`       | publish this, make this public, publish a guide, share with community       | [PUBLISH](#publish)   |
+| `get <id\|alias>`      | get this ID, load this ID, restore from ID, read alias, open alias          | [GET](#get)           |
+| `find <query>`         | what context do I have, load my context, search                             | [FIND](#find)         |
+| `update [<id\|alias>]` | edit this pack, update my last pack                                         | [UPDATE](#update)     |
+| `organize`             | reorganize blocks, split this, clean up                                     | [ORGANIZE](#organize) |
+| `suggest`              | suggest a change, propose an edit, review suggestions, resolve a suggestion | [SUGGEST](#suggest)   |
+| —                      | unclear intent                                                              | Ask once              |
 
-## Operations (context packs)
+## Operations
 
-| Operation      | CLI                                                                             | MCP                  |
-| -------------- | ------------------------------------------------------------------------------- | -------------------- |
-| `search pack`  | `epismo pack search --type context [--query <keywords>] [--filter '{...}']`     | `epismo_pack_search` |
-| `get pack`     | `epismo pack get <id> [--full] [--block-id <id>]`<br>`epismo pack get @<alias>` | `epismo_pack_get`    |
-| `create pack`  | `epismo pack create --input '<json>'`                                           | `epismo_pack_create` |
-| `update pack`  | `epismo pack update <id> --input '<json>'`                                      | `epismo_pack_update` |
-| `delete pack`  | `epismo pack delete <id>`                                                       | `epismo_pack_delete` |
-| `like pack`    | `epismo pack like <id> --liked`                                                 | `epismo_pack_like`   |
-| `upsert alias` | `epismo alias upsert @<name> --id <id>`                                         | —                    |
-| `get alias`    | `epismo alias get @<name>`                                                      | —                    |
-| `list aliases` | `epismo alias list --type context`                                              | —                    |
-| `delete alias` | `epismo alias delete @<name>`                                                   | —                    |
+| Operation            | CLI                                                                         |
+| -------------------- | --------------------------------------------------------------------------- |
+| `search pack`        | `epismo pack search --type context [--query <keywords>] [--filter '{...}']` |
+| `get pack`           | `epismo pack get <reference> [--full] [--block-id <id>]`                    |
+| `create pack`        | `epismo pack create --input '<json>'`                                       |
+| `update pack`        | `epismo pack update <reference> --input '<json>'`                           |
+| `delete pack`        | `epismo pack delete <reference>`                                            |
+| `like pack`          | `epismo pack like <reference> --liked`                                      |
+| `upsert alias`       | `epismo alias upsert @<name> --id <id>`                                     |
+| `get alias`          | `epismo alias get @<name>`                                                  |
+| `list aliases`       | `epismo alias list --type context`                                          |
+| `delete alias`       | `epismo alias delete @<name>`                                               |
+| `create suggestion`  | `epismo suggestion create <reference> --title <t> --content <c>`            |
+| `get suggestion`     | `epismo suggestion get <id> [--include-snapshot]`                           |
+| `list suggestions`   | `epismo suggestion list [--owner] [--reference <ref>] [--status <s>]`       |
+| `update suggestion`  | `epismo suggestion update <id> --title <t> --content <c>`                   |
+| `resolve suggestion` | `epismo suggestion resolve <id> --status <applied\|declined\|archived>`     |
+
+CLI forms shown; on MCP, derive the tool name mechanically (`pack get` → `epismo_pack_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
+
+`<reference>` is any pack reference — an ID, `@alias`, share URL, or hub URL — resolved server-side. See [Pack References](../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
 
 ---
 
@@ -214,7 +226,7 @@ Confirm with user, then `create pack`:
 }
 ```
 
-Return ID, title, and share URL. For share URL resolution, see [Epismo Basics — Resolving Share URLs](../epismo-basics/SKILL.md#resolving-share-urls).
+Return ID, title, and share URL. A share URL can be passed straight back to `pack get` as a `reference`; see [Epismo Basics — Pack References](../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
 
 ```
 context  <context-id>  <context-title>
@@ -312,6 +324,29 @@ The most common need is not managing many packs — it's making the blocks insid
 | The whole pack is no longer needed                    | **Delete** — delete the pack (needs approval)                 |
 
 All changes are applied via `update pack` using `op` fields. Use `"op": "add"` for new blocks, `"op": "update"` for existing ones, `"op": "remove"` to delete a block by ID. `delete pack` requires explicit user approval.
+
+---
+
+## SUGGEST
+
+**Goal:** propose an improvement to a context pack you don't own, or review and resolve suggestions on a pack you do own. Suggestions are text-first — they never edit the pack directly.
+
+Full lifecycle, listing modes, and the CLI/MCP surface are in [Suggestions](../epismo-basics/references/suggestions.md). Decide direction first:
+
+| Intent                                  | Action                                                                                               |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Propose a change to someone else's pack | `create suggestion` with the pack reference, a short title, and content describing the proposed edit |
+| See suggestions I've received (inbox)   | `list suggestions --owner` (filter with `--status open`)                                             |
+| See suggestions for one pack            | `list suggestions --reference @<alias>`                                                              |
+| See suggestions I submitted             | `list suggestions` (no flags)                                                                        |
+| Revise my own suggestion                | `update suggestion <id>` (author only)                                                               |
+| Act on a suggestion I received          | `resolve suggestion <id> --status applied\|declined\|archived` (owner only)                          |
+
+When you **apply** a suggestion, make the actual change via [UPDATE](#update) or [ORGANIZE](#organize) first, then `resolve --status applied`. Resolving alone does not edit the pack.
+
+```
+suggestion  <suggestion-id>  <suggestion-title>  <status>
+```
 
 ---
 

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -92,12 +92,6 @@ epismo pack get <pack-id> --block-id <block-id>
 
 `get pack` without `--full` returns outline only (`id`, `title`, `view`, `contentIndex`). Use `--full` to load all block content into the session.
 
-**MCP equivalent:**
-
-```
-epismo_pack_get  # with id parameter; pass full=true for full content
-```
-
 ### Loading into a new session
 
 When resuming work in a new tool or session:

--- a/skills/context-pack/references/visibility.md
+++ b/skills/context-pack/references/visibility.md
@@ -96,7 +96,7 @@ Obtain the share token from the create/update response or from the Epismo UI. Th
 https://epismo.ai/hub/contexts/{pack-id}
 ```
 
-**Resolving a share URL to an pack ID:** see [Epismo Basics — Resolving Share URLs](../../epismo-basics/SKILL.md#resolving-share-urls).
+**Opening a share URL:** pass the whole URL as the `reference` to `pack get` — it resolves server-side. See [Epismo Basics — Pack References](../../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
 
 ### Who Can Use a Share URL
 

--- a/skills/epismo-basics/SKILL.md
+++ b/skills/epismo-basics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: epismo-basics
-description: "Shared Epismo operating model: CLI/MCP surface conventions, workspace and project scope, share URL resolution, selective fetch and pack reuse patterns, pack aliases, credits/payment handling, and common auth or permission errors. Load this alongside any Epismo skill, or trigger on Epismo usage questions, alias/credit issues, share URLs, workspace scope, or setup/auth problems blocking another Epismo task."
+description: "Shared Epismo operating model: CLI/MCP surface conventions, workspace and project scope, share URL resolution, selective fetch and pack reuse patterns, pack aliases, pack suggestions, credits/payment handling, and common auth or permission errors. Load this alongside any Epismo skill, or trigger on Epismo usage questions, alias/credit issues, share URLs, workspace scope, or setup/auth problems blocking another Epismo task."
 ---
 
 # Epismo Basics
@@ -42,11 +42,17 @@ epismo whoami                           # verify
 | `cli`   | `epismo <resource> <action> [--flags]` | `epismo pack search --type context` |
 | `mcp`   | `epismo_<resource>_<action>` + JSON    | `epismo_pack_search`                |
 
-MCP tool name = CLI command with spaces and hyphens replaced by underscores. Conceptual payloads are the same across surfaces; CLI flags are mapped into the JSON shape used by API/MCP.
+MCP tool name = CLI command with spaces and hyphens replaced by underscores (e.g. `epismo pack get` → `epismo_pack_get`). Conceptual payloads are the same across surfaces; each `--kebab-flag` becomes a camelCase JSON key (`--include-snapshot` → `includeSnapshot`), and a repeatable / comma-separated flag becomes an array (`--status open,applied` → `statuses: ["open", "applied"]`). **Skill docs show CLI forms only** — derive the MCP tool and parameters from these rules rather than re-listing them per page.
+
+**CLI is the full surface; MCP is a subset.** Prefer MCP or CLI and ignore the HTTP API in normal use. Some surfaces are **CLI-only** (no `epismo_*` tool): `login` / `logout` / `whoami`, `workspace`, `project`, `agent`, `credit`, and `token` — use the CLI for these.
 
 ### Pack Aliases
 
 Packs can be fetched by a short alias instead of a full ID. On the CLI, pass the alias (with or without `@` prefix) as the positional `<reference>` to `pack get` — same slot the ID goes in. In MCP, pass it via the `reference` parameter. To create and manage aliases, see [Pack Alias](./references/pack-alias.md).
+
+### Suggestions
+
+Anyone who can read a workflow or context pack can send the owner a text-first improvement suggestion, and the owner reviews and resolves it (`open` → `applied` / `declined` / `archived`). Suggestions never edit the pack directly. The surface is shared across both pack skills — see [Suggestions](./references/suggestions.md) for the lifecycle, listing modes, and CLI/MCP operations.
 
 ### CLI Input Conventions
 
@@ -90,45 +96,21 @@ When the user refers to "my project", resolve both layers before writing:
 
 ---
 
-## Resolving Share URLs
+## Pack References (Resolving Share URLs)
 
-Share URLs resolve to a resource without credentials by following the HTTP redirect.
+Pack-level commands (`get`, `update`, `like`, `delete`) take a **single `reference`** — the server resolves it. You never follow redirects or extract IDs yourself; pass the user's value as-is.
 
-- Public packs typically use `https://epismo.ai/share/{token}`.
-- Internal/private workspace packs may use `https://{workspace}.epismo.ai/share/{token}`.
-- Do not assume the host is always the root domain; preserve the original host from the share URL.
+| Reference form | Example                                                                            |
+| -------------- | ---------------------------------------------------------------------------------- |
+| Artifact ID    | `abc-123-...`                                                                      |
+| Alias          | `@myproject`, `@handle/myproject`                                                  |
+| Share URL      | `https://epismo.ai/share/{token}` or `https://{workspace}.epismo.ai/share/{token}` |
+| Hub URL        | `https://epismo.ai/hub/workflows/{id}`, `https://epismo.ai/hub/contexts/{id}`      |
 
-```bash
-# curl
-curl -s -o /dev/null -w "%{redirect_url}" "https://epismo.ai/share/${TOKEN}"
-# → https://epismo.ai/hub/workflows/{id}
-# → https://epismo.ai/hub/contexts/{id}
+- **CLI** — positional `<reference>`: `epismo pack get <reference>`.
+- **MCP** — `reference` parameter on the `epismo_pack_*` tools.
 
-# internal/private packs may redirect from a workspace subdomain instead
-curl -s -o /dev/null -w "%{redirect_url}" "https://${WORKSPACE}.epismo.ai/share/${TOKEN}"
-# → https://${WORKSPACE}.epismo.ai/hub/workflows/{id}
-# → https://${WORKSPACE}.epismo.ai/hub/contexts/{id}
-```
-
-```typescript
-// fetch (Node.js)
-const shareUrl = new URL(process.argv[2]);
-const res = await fetch(shareUrl, {
-  redirect: "manual",
-});
-const location = res.headers.get("location") ?? "";
-
-const workflowMatch = location.match(/\/hub\/workflows\/([^/?#]+)/);
-const contextMatch = location.match(/\/hub\/contexts\/([^/?#]+)/);
-// use whichever matches; id = decodeURIComponent(match[1])
-```
-
-| Redirect path         | Resource type   |
-| --------------------- | --------------- |
-| `/hub/workflows/{id}` | `workflow` pack |
-| `/hub/contexts/{id}`  | `context` pack  |
-
-Use the resolved `id` with `get pack` on any surface. If the original share URL is on a workspace subdomain, keep using that host when handing the link back to the user.
+Share URLs resolve server-side by token, independent of host — a workspace-subdomain share URL works without special handling, and no credentials or redirect-following are needed. The resolved pack type (`workflow` / `context`) comes back in the response.
 
 ---
 

--- a/skills/epismo-basics/references/credit-purchase.md
+++ b/skills/epismo-basics/references/credit-purchase.md
@@ -6,34 +6,29 @@ When an operation returns `Payment Required: Insufficient credits`, check the cu
 
 **Minimum purchase: 500 credits ($5.00) total per checkout**
 
-## Access Options
+Credits are **CLI-only** — there is no MCP tool for `credit`. Run the steps below with `epismo`.
 
-- **CLI** — preferred when operating interactively. Run `epismo login` to authenticate.
-- **API (curl / scripted)** — use when building an integration or when the CLI is not available. Requires an OAuth `access_token`.
-
-### CLI
-
-#### Step 1. Authenticate (If Needed)
+### Step 1. Authenticate (If Needed)
 
 ```bash
 epismo login --email you@example.com
 epismo login --browser
 ```
 
-#### Step 2. Check Credit Status
+### Step 2. Check Credit Status
 
 ```bash
 epismo credit balance
 ```
 
-#### Step 3. Purchase Credits (Create Stripe Checkout)
+### Step 3. Purchase Credits (Create Stripe Checkout)
 
 ```bash
 epismo credit checkout --allocations '[{"userId":"<USER_ID>","quantity":500}]'
 epismo credit checkout --input @checkout.json
 ```
 
-#### Step 4. Complete the Purchase
+### Step 4. Complete the Purchase
 
 Open the returned Stripe Checkout URL in your browser and complete payment.
 
@@ -41,77 +36,3 @@ Open the returned Stripe Checkout URL in your browser and complete payment.
 2. Verify the updated balance with `epismo credit balance`.
 3. Retry the CLI call that failed with insufficient credits.
 4. If your session expired while purchasing, run `epismo login` again and retry.
-
-### API
-
-#### Step 1. Get an OAuth Access Token (If Needed)
-
-If you do not already have an `access_token`, request an OTP and exchange it with the PIN sent to your email.
-
-```bash
-curl -sX POST https://api.epismo.ai/v1/otp-tokens \
-  -H "Content-Type: application/json" \
-  -d '{"email":"you@example.com"}'
-
-# => {"otpId":"<OTP_ID>"}
-```
-
-```bash
-curl -sX POST https://api.epismo.ai/oauth/token \
-  -H "Content-Type: application/json" \
-  -d '{"grant_type":"otp","otp_id":"<OTP_ID>","pin":"<PIN_FROM_EMAIL>"}'
-
-# => {"access_token":"<ACCESS_TOKEN>","refresh_token":"<REFRESH_TOKEN>","token_type":"Bearer","expires_in":3600,"scope":"read write offline_access","user_id":"<USER_ID>"}
-```
-
-#### Step 2. Check Credit Status
-
-Call `GET /v1/credits` with `Authorization: Bearer <ACCESS_TOKEN>`.
-
-- `workspaceId` (optional query): target workspace. If provided, the caller must belong to that workspace.
-- Response: `{ "balance": <NUMBER>, "shortfall": <NUMBER> }`
-
-```bash
-curl -sX GET "https://api.epismo.ai/v1/credits?workspaceId=<workspace-id>" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-
-# => {"balance":100,"shortfall":0}
-```
-
-Omit the `workspaceId` query parameter to check personal scope.
-
-#### Step 3. Purchase Credits (Create Stripe Checkout)
-
-Call `POST /v1/credits` with `Authorization: Bearer <ACCESS_TOKEN>`.
-
-- `workspaceId` (optional): target workspace. If provided, the caller must belong to that workspace.
-- `allocations`: recipients and quantities.
-- `userId`: recipient user ID.
-- `quantity`: number of credits (integer). The allocation total must be at least 500 credits.
-
-```bash
-curl -sX POST https://api.epismo.ai/v1/credits \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>" \
-  -d '{
-    "workspaceId": "<workspace-id>",
-    "allocations": [
-      {
-        "userId": "...",
-        "quantity": 1000
-      }
-    ]
-  }'
-
-# Response:
-# {"url":"https://checkout.stripe.com/..."}
-```
-
-#### Step 4. Complete the Purchase
-
-Open the returned Stripe Checkout `url` in your browser and complete payment.
-
-1. Credits are added to the specified balance.
-2. Verify the updated balance with `GET /v1/credits`.
-3. Retry the API call that failed with insufficient credits.
-4. If the access token expired while purchasing, rerun the OTP flow and retry.

--- a/skills/epismo-basics/references/pack-alias.md
+++ b/skills/epismo-basics/references/pack-alias.md
@@ -2,7 +2,7 @@
 
 An alias is a short, human-readable name that resolves to a pack ID. Pass it as the positional `<reference>` to `pack get` (same slot as the ID) to avoid copying and pasting full UUIDs.
 
-`alias` is a top-level resource — managed via `epismo alias ...` (CLI) or `/v1/aliases` (API), separate from pack CRUD.
+`alias` is a top-level resource — managed via `epismo alias ...` (CLI) or `epismo_alias_*` (MCP), separate from pack CRUD. Both surfaces cover the full set: `upsert`, `get`, `list`, and `delete`.
 
 ## Namespaces
 
@@ -21,7 +21,7 @@ On **upsert / delete**, pick the namespace with `--namespace personal|workspace`
 | `@<handle>/<alias>`    | another account's alias, by public handle                      |
 
 - The bare form keeps daily use short while letting a personal alias shadow a shared team one.
-- The namespace is **not** encoded in the reference string (any `@me/`/`@team/`-style prefix would collide with real account handles, which are plain `[a-z0-9-]`). To pin resolution to one side when a personal alias shadows a workspace one, pass `--namespace personal|workspace` (CLI) / `namespace` (API/MCP) alongside the bare alias.
+- The namespace is **not** encoded in the reference string (any `@me/`/`@team/`-style prefix would collide with real account handles, which are plain `[a-z0-9-]`). To pin resolution to one side when a personal alias shadows a workspace one, pass `--namespace personal|workspace` (CLI) / `namespace` (MCP) alongside the bare alias.
 
 ## Who can create an alias
 
@@ -29,12 +29,12 @@ Only the pack's **owner** may create or repoint an alias to it (in either the pe
 
 ## Access Options
 
-- **CLI** — preferred when operating interactively. Credentials from `epismo login` are used automatically.
-- **API (curl / scripted)** — use when building an integration or when the CLI is not available. Requires an OAuth `access_token`; to obtain one, see [Auth Setup](../SKILL.md#auth-setup-cli) in Epismo Basics.
+- **CLI** — the full surface (`upsert`, `get`, `list`, `delete`). Credentials from `epismo login` are used automatically.
+- **MCP** — the same four operations as `epismo_alias_*` tools (derive names mechanically; see [surface conventions](../SKILL.md#surface-conventions)). To fetch the pack itself, pass the reference to `epismo_pack_get`.
+
+The CLI forms below apply to both surfaces.
 
 ---
-
-### CLI
 
 #### Upsert (create or update)
 
@@ -82,67 +82,7 @@ epismo pack get @handle/myproject
 epismo pack get @mycontext --block-id <block-id>
 ```
 
----
-
-### API (curl / scripted)
-
-`accountId` is never passed as a request parameter — the API resolves it from the auth token internally.
-
-#### Upsert
-
-`namespace` is optional (`personal` default, or `workspace`). The workspace is taken from the auth token / `workspaceId` query param.
-
-```bash
-curl -sX PUT https://api.epismo.ai/v1/aliases \
-  -H "Authorization: Bearer <ACCESS_TOKEN>" \
-  -H "Content-Type: application/json" \
-  -d '{"type":"workflow","id":"<pack-id>","alias":"@myproject","namespace":"personal"}'
-```
-
-#### List
-
-```bash
-curl -sX GET https://api.epismo.ai/v1/aliases \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-```
-
-#### Get (resolve a single alias)
-
-```bash
-# Own alias (personal, then workspace fallback)
-curl -sX GET "https://api.epismo.ai/v1/aliases?alias=%40myproject" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-
-# Pin to the workspace namespace
-curl -sX GET "https://api.epismo.ai/v1/aliases?alias=%40deploy&namespace=workspace" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-
-# Another user's alias
-curl -sX GET "https://api.epismo.ai/v1/aliases?alias=%40epismo%2Fmyproject" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-
-# With type filter
-curl -sX GET "https://api.epismo.ai/v1/aliases?alias=%40myproject&type=workflow" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-```
-
-#### Delete
-
-```bash
-curl -sX DELETE "https://api.epismo.ai/v1/aliases/%40myproject" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-
-# workspace-scoped alias
-curl -sX DELETE "https://api.epismo.ai/v1/aliases/%40deploy?namespace=workspace" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-```
-
-#### Use an alias to fetch a pack
-
-```bash
-curl -sX GET "https://api.epismo.ai/v1/packs?alias=%40myproject" \
-  -H "Authorization: Bearer <ACCESS_TOKEN>"
-```
+`get` resolves an alias to its pack metadata (`id`, `type`, `namespace`, `reference`); to fetch the pack's content, pass that reference straight to `pack get` — the same slot the alias goes in.
 
 ---
 

--- a/skills/epismo-basics/references/suggestions.md
+++ b/skills/epismo-basics/references/suggestions.md
@@ -1,0 +1,83 @@
+# Suggestions
+
+A suggestion is a text-first improvement proposal sent to a pack's **owner**. Anyone who can read a workflow or context pack can suggest a change to it; the owner reviews and resolves it. Suggestions never edit the pack directly — proposed edits go in the suggestion `content`, and the owner applies them through a normal `update pack`.
+
+`suggestion` is a top-level resource — managed via `epismo suggestion ...` (CLI) or `epismo_suggestion_*` (MCP), separate from pack CRUD.
+
+## Lifecycle
+
+Every suggestion has a `status`:
+
+| Status     | Meaning                                                   | Set by          |
+| ---------- | --------------------------------------------------------- | --------------- |
+| `open`     | Submitted, awaiting the owner's decision (initial state). | author (create) |
+| `applied`  | Owner accepted it; the change has been (or will be) made. | owner (resolve) |
+| `declined` | Owner decided not to act on it.                           | owner (resolve) |
+| `archived` | Set aside without a decision; keeps the inbox clean.      | owner (resolve) |
+
+`open` → `applied` / `declined` / `archived`. The owner can move a suggestion back to `open` with `resolve --status open`.
+
+## Snapshot
+
+When a suggestion is created, the pack's content at that moment is captured as an immutable **snapshot**. The suggestion stays anchored to what the author actually saw even if the pack changes later. Read it with `--include-snapshot` (get) or `--include-snapshots` (list). It is omitted by default to keep responses small.
+
+## Who can do what
+
+| Action                 | Who                                                    |
+| ---------------------- | ------------------------------------------------------ |
+| Create                 | Anyone who can read the pack (private or public).      |
+| Update (title/content) | The **author** only.                                   |
+| Resolve (status)       | The pack **owner** only.                               |
+| Get / List             | Anyone whose ACL grants read access to the suggestion. |
+
+Creating a suggestion costs **5 credits**, `list` costs **2 credits**, and `get`, `update`, and `resolve` cost **1 credit** each. Creation is additionally capped at **20 suggestions per day** per account; beyond that, create fails with a daily-limit error.
+
+## Reference resolution
+
+`create` and `list --reference` accept the same pack reference forms as `pack get`: a pack ID, an `@alias`, a share URL, or a hub URL. See [Pack Alias](./pack-alias.md) for alias forms and [Pack References](../SKILL.md#pack-references-resolving-share-urls) for share/hub links.
+
+## Listing modes
+
+`list` answers three different questions depending on the flags:
+
+| Goal                                      | Flags                                       |
+| ----------------------------------------- | ------------------------------------------- |
+| Suggestions **I submitted** (default)     | _(no flags)_                                |
+| My **inbox** — suggestions on packs I own | `--owner`                                   |
+| Suggestions **for one pack**              | `--reference @pack` (optionally `--author`) |
+
+Add `--status open` (or a comma-separated list) to filter by lifecycle state, and `--page` to paginate (page size 20).
+
+`list` returns each suggestion's `content` as a truncated preview — the same selective-fetch pattern packs use. Use `get` to read the full content.
+
+---
+
+## CLI
+
+```bash
+# Send an improvement suggestion to a pack owner
+epismo suggestion create @market-research --title "Add review step" \
+  --content "Add a final human review before publishing to reduce hallucinated findings."
+epismo suggestion create <pack-id> --input @suggestion.json
+
+# Read one suggestion, optionally with the captured pack snapshot
+epismo suggestion get <suggestion-id>
+epismo suggestion get <suggestion-id> --include-snapshot
+
+# List: submitted (default), inbox, or per-pack
+epismo suggestion list                              # suggestions you submitted
+epismo suggestion list --owner --status open        # your inbox, open only
+epismo suggestion list --reference @market-research # for one pack
+epismo suggestion list --status open,declined
+
+# Edit your own suggestion (author only)
+epismo suggestion update <suggestion-id> --title "Add review step" \
+  --content "Please add a reviewer approval step before publish."
+
+# Resolve a suggestion you received (owner only)
+epismo suggestion resolve <suggestion-id> --status applied
+```
+
+`--status` accepts `open`, `applied`, `declined`, or `archived`.
+
+On MCP, derive the tool name mechanically (`suggestion list` → `epismo_suggestion_list`); flags become camelCase parameters and `--status open,applied` becomes `statuses: ["open", "applied"]`. See [surface conventions](../SKILL.md#surface-conventions).

--- a/skills/project-tracking/SKILL.md
+++ b/skills/project-tracking/SKILL.md
@@ -16,14 +16,16 @@ Operate on tasks and goals in Epismo projects — from a quick status update to 
 
 ## Operations
 
-| Operation      | CLI                                                      | MCP                   |
-| -------------- | -------------------------------------------------------- | --------------------- |
-| `search track` | `epismo track search --type task\|goal --filter '{...}'` | `epismo_track_search` |
-| `get track`    | `epismo track get <id>`                                  | `epismo_track_get`    |
-| `create track` | `epismo track create --input '<json>'`                   | `epismo_track_create` |
-| `update track` | `epismo track update <id> --input '<json>'`              | `epismo_track_update` |
-| `delete track` | `epismo track delete <id>`                               | `epismo_track_delete` |
-| `apply track`  | `epismo track apply --input '<json>'`                    | `epismo_track_apply`  |
+| Operation      | CLI                                                      |
+| -------------- | -------------------------------------------------------- |
+| `search track` | `epismo track search --type task\|goal --filter '{...}'` |
+| `get track`    | `epismo track get <id>`                                  |
+| `create track` | `epismo track create --input '<json>'`                   |
+| `update track` | `epismo track update <id> --input '<json>'`              |
+| `delete track` | `epismo track delete <id>`                               |
+| `apply track`  | `epismo track apply --input '<json>'`                    |
+
+CLI forms shown; on MCP, derive the tool name mechanically (`track get` → `epismo_track_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
 
 For filter keys, status values, entity relationships, and search recipes, see [Search & Filter](./references/search.md).
 

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-pack
-description: "Discover, reuse, and release workflow packs in Epismo. Trigger on: 'find a workflow', 'get <id>', 'read <alias>', 'new workflow', 'create workflow', 'capture pattern', 'adapt a workflow', 'reuse this pattern', 'update workflow', 'organize steps', 'release this as a workflow', 'publish a workflow', 'deprecate workflow', or any intent to search community workflows or capture a proven execution pattern for reuse."
+description: "Discover, reuse, and release workflow packs in Epismo. Trigger on: 'find a workflow', 'get <id>', 'read <alias>', 'new workflow', 'create workflow', 'capture pattern', 'adapt a workflow', 'reuse this pattern', 'update workflow', 'organize steps', 'release this as a workflow', 'publish a workflow', 'deprecate workflow', 'suggest a change to a workflow', 'review suggestions', 'resolve a suggestion', or any intent to search community workflows or capture a proven execution pattern for reuse."
 ---
 
 # Workflow Pack
@@ -12,6 +12,7 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 > For connection setup, surface conventions, scope model, share URL resolution, and error handling, see [Epismo Basics](../epismo-basics/SKILL.md).
 > For task/goal tracking, see [Project Tracking](../project-tracking/SKILL.md).
 > For workflow query patterns and loading, see [Search & Discovery](./references/search.md).
+> For sending and resolving improvement suggestions, see [Suggestions](../epismo-basics/references/suggestions.md).
 
 ## Commands
 
@@ -23,22 +24,32 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | `update [<id\|alias>]`  | edit steps, update workflow, modify steps                             | [UPDATE](#update)     |
 | `organize`              | reorganize steps, reorder, clean up workflow                          | [ORGANIZE](#organize) |
 | `release [<id\|alias>]` | publish this, make public, release pattern, update release, deprecate | [RELEASE](#release)   |
+| `suggest`               | suggest a change, propose an edit, review suggestions, resolve a suggestion | [SUGGEST](#suggest) |
 | —                       | unclear intent                                                        | Ask once              |
 
 ## Operations
 
-| Operation      | CLI                                                                             | MCP                  |
-| -------------- | ------------------------------------------------------------------------------- | -------------------- |
-| `search pack`  | `epismo pack search --type workflow --filter '{...}'`                           | `epismo_pack_search` |
-| `get pack`     | `epismo pack get <id> [--full] [--step-id <ids>]`<br>`epismo pack get @<alias>` | `epismo_pack_get`    |
-| `create pack`  | `epismo pack create --input '<json>'`                                           | `epismo_pack_create` |
-| `update pack`  | `epismo pack update <id> --input '<json>'`                                      | `epismo_pack_update` |
-| `delete pack`  | `epismo pack delete <id>`                                                       | `epismo_pack_delete` |
-| `like pack`    | `epismo pack like <id> --liked`                                                 | `epismo_pack_like`   |
-| `upsert alias` | `epismo alias upsert @<name> --id <id>`                                         | —                    |
-| `get alias`    | `epismo alias get @<name>`                                                      | —                    |
-| `list aliases` | `epismo alias list --type workflow`                                             | —                    |
-| `delete alias` | `epismo alias delete @<name>`                                                   | —                    |
+| Operation      | CLI                                                                             |
+| -------------- | ------------------------------------------------------------------------------- |
+| `search pack`  | `epismo pack search --type workflow --filter '{...}'`                           |
+| `get pack`     | `epismo pack get <reference> [--full] [--step-id <ids>]`                        |
+| `create pack`  | `epismo pack create --input '<json>'`                                           |
+| `update pack`  | `epismo pack update <reference> --input '<json>'`                               |
+| `delete pack`  | `epismo pack delete <reference>`                                                |
+| `like pack`    | `epismo pack like <reference> --liked`                                          |
+| `upsert alias` | `epismo alias upsert @<name> --id <id>`                                         |
+| `get alias`    | `epismo alias get @<name>`                                                      |
+| `list aliases` | `epismo alias list --type workflow`                                             |
+| `delete alias` | `epismo alias delete @<name>`                                                   |
+| `create suggestion`  | `epismo suggestion create <reference> --title <t> --content <c>`          |
+| `get suggestion`     | `epismo suggestion get <id> [--include-snapshot]`                         |
+| `list suggestions`   | `epismo suggestion list [--owner] [--reference <ref>] [--status <s>]`     |
+| `update suggestion`  | `epismo suggestion update <id> --title <t> --content <c>`                 |
+| `resolve suggestion` | `epismo suggestion resolve <id> --status <applied\|declined\|archived>`   |
+
+CLI forms shown; on MCP, derive the tool name mechanically (`pack get` → `epismo_pack_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
+
+`<reference>` is any pack reference — an ID, `@alias`, share URL, or hub URL — resolved server-side. See [Pack References](../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
 
 ---
 
@@ -294,6 +305,29 @@ See [Release](./references/release.md) for the approval boundary and required ou
 ```
 workflow  <workflow-id>  <workflow-title>
 share     https://epismo.ai/hub/workflows/<id>
+```
+
+---
+
+## SUGGEST
+
+**Goal:** propose an improvement to a workflow you don't own, or review and resolve suggestions on a workflow you do own. Suggestions are text-first — they never edit the workflow directly.
+
+Full lifecycle, listing modes, and the CLI/MCP surface are in [Suggestions](../epismo-basics/references/suggestions.md). Decide direction first:
+
+| Intent                                              | Action                                                                 |
+| --------------------------------------------------- | ---------------------------------------------------------------------- |
+| Propose a change to someone else's workflow         | `create suggestion` with the pack reference, a short title, and content describing the proposed edit |
+| See suggestions I've received (inbox)               | `list suggestions --owner` (filter with `--status open`)               |
+| See suggestions for one workflow                    | `list suggestions --reference @<alias>`                                |
+| See suggestions I submitted                         | `list suggestions` (no flags)                                          |
+| Revise my own suggestion                            | `update suggestion <id>` (author only)                                 |
+| Act on a suggestion I received                      | `resolve suggestion <id> --status applied\|declined\|archived` (owner only) |
+
+When you **apply** a suggestion, make the actual change via [UPDATE](#update) or [ORGANIZE](#organize) first, then `resolve --status applied`. Resolving alone does not edit the workflow.
+
+```
+suggestion  <suggestion-id>  <suggestion-title>  <status>
 ```
 
 ---

--- a/skills/workflow-pack/references/visibility.md
+++ b/skills/workflow-pack/references/visibility.md
@@ -72,14 +72,9 @@ After publishing, deliver to the intended audience via share URL.
 
 ### Share URL
 
-Obtain the share token from the create or update response or the Epismo UI. Resolve it to a pack ID:
+Obtain the share URL from the create or update response or the Epismo UI and hand it to the recipient. To open it yourself, pass the whole URL as the `reference` to `pack get` — it resolves server-side, no token extraction needed.
 
-```bash
-curl -s -o /dev/null -w "%{redirect_url}" "https://epismo.ai/share/${TOKEN}"
-# → https://epismo.ai/hub/workflows/{id}
-```
-
-See [Epismo Basics — Resolving Share URLs](../../epismo-basics/SKILL.md#resolving-share-urls) for the full algorithm.
+See [Epismo Basics — Pack References](../../epismo-basics/SKILL.md#pack-references-resolving-share-urls) for all accepted reference forms.
 
 ### Who Can Use a Share URL
 


### PR DESCRIPTION
## Summary

Make the **CLI the canonical surface** across the Epismo skills and stop re-listing the MCP tool catalog on every page. An MCP tool name and its parameters are derived mechanically from the CLI form, so the rule is documented **once** in Epismo Basics and CLI forms are shown everywhere else.

This removes a recurring inconsistency: some pages carried full MCP tool lists/columns while others just stated the naming rule. Now there is one convention.

## Changes

- **epismo-basics** — Strengthen the surface-conventions rule to also cover parameter mapping (`--kebab-flag` → camelCase JSON key, repeatable / comma-separated flags → arrays) and state explicitly that **skill docs show CLI forms only**. Drop the now-stale "MCP column" reference.
- **context-pack / workflow-pack / project-tracking** — Drop the duplicate **MCP column** from the operation tables; add a one-line derivation note linking to the surface conventions.
- **pack-alias / suggestions** — Remove the dedicated `## MCP` tables in favor of the shared derivation rule.
- **credit-purchase** — Drop the parallel HTTP API / curl walkthrough; credits are CLI-only.
- **visibility (context + workflow)** — Resolve share URLs by passing the whole URL as the `reference` to `pack get` (server-side resolution) instead of manual token/redirect extraction.

## Why

The operation tables themselves stay — in context-pack and project-tracking they are the *only* place concrete CLI syntax lives, with the workflow sections written as prose that relies on them. What was redundant was the MCP enumeration duplicating mechanically-derivable names. That single source now lives in Epismo Basics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)