### PR TITLE
docs(search): document searchMode (keyword/semantic) across search references

### DIFF
--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -11,7 +11,7 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 
 | Operation     | CLI command                         | Key flags                                               |
 | ------------- | ----------------------------------- | ------------------------------------------------------- |
-| `search pack` | `epismo pack search --type context` | `--query <keywords>` `--filter '{...}'` `--projects`    |
+| `search pack` | `epismo pack search --type context` | `--query <keywords>` `--filter '{...}'` `--projects` `--search-mode` |
 | `get pack`    | `epismo pack get <id>`              | `[--full]` `[--block-id <block-id>]`                    |
 | `like pack`   | `epismo pack like <id> --liked`     | `--no-liked` to remove                                  |
 
@@ -36,7 +36,7 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 4. `filter.visibility=["public"]` returns all public packs discoverable from the active workspace.
 5. `scopes=[{type:"projects", ids:["<project-id>"]}]` narrows private search scope to that project. In CLI, pass `--projects <ids>`.
 6. Add `{type:"personal"}` to `scopes` to include packs that target the current user directly. In CLI, pass `--personal`.
-7. `query` runs a semantic / keyword search on title and content. Keep it to 2–6 domain keywords.
+7. `query` searches title and content. Keep it to 2–6 domain keywords. `searchMode` defaults to `keyword`; pass `semantic` (CLI `--search-mode semantic`) to add vector similarity for paraphrased or cross-language queries. See [Epismo Basics — Search Ranking Mode](../../epismo-basics/SKILL.md#search-ranking-mode).
 8. Omitting all filters returns the most recently updated packs in the active workspace.
 
 ## Supported Filter Keys

--- a/skills/epismo-basics/SKILL.md
+++ b/skills/epismo-basics/SKILL.md
@@ -149,6 +149,15 @@ Before creating any new pack, scan private and public candidates for the same to
 
 If a close match is found, prefer `get pack` over creating new.
 
+## Search Ranking Mode
+
+`search pack` and `search track` accept `searchMode`: `keyword` (default) or `semantic`. Keyword matches terms in title and content; semantic adds vector similarity, so it also surfaces paraphrases and cross-language matches. Default to `keyword`; use `semantic` when the user describes intent in their own words rather than exact terms. In CLI, pass `--search-mode keyword|semantic`.
+
+```bash
+epismo pack search --type context --query "how onboarding works" --search-mode semantic
+epismo track search --type task --query "login is broken" --search-mode semantic
+```
+
 ## Pagination
 
 All `search` calls return page size 20. For large result sets, iterate `page=1, 2, 3...` and merge results.

--- a/skills/project-tracking/references/search.md
+++ b/skills/project-tracking/references/search.md
@@ -9,7 +9,7 @@ For reusable workflow discovery, see [Workflow Pack — Search & Discovery](../.
 
 | Operation      | CLI command                | Key flags                                              |
 | -------------- | -------------------------- | ------------------------------------------------------ |
-| `search track` | `epismo track search`      | `--type task\|goal` `--filter '{...}'` `--projects`    |
+| `search track` | `epismo track search`      | `--type task\|goal` `--filter '{...}'` `--projects` `--search-mode` |
 | `get track`    | `epismo track get <id>`    | —                                                      |
 | `create track` | `epismo track create`      | `--input @item.json` or `--projects <ids>`             |
 | `update track` | `epismo track update <id>` | `--input @item.json` or `--projects <ids>`             |
@@ -37,6 +37,7 @@ For reusable workflow discovery, see [Workflow Pack — Search & Discovery](../.
 5. Project write scope is `scope:{type:"projects", ids:[...]}`. In CLI, pass `--projects <ids>`.
 6. `search track` requires `type`: `task` or `goal`.
 7. Keep `query` compact when searching related workflow packs through Workflow Pack: 2-6 domain keywords.
+8. `searchMode` defaults to `keyword`; pass `semantic` (CLI `--search-mode semantic`) to add vector similarity for intent-described queries. See [Epismo Basics — Search Ranking Mode](../../epismo-basics/SKILL.md#search-ranking-mode).
 
 ## Entity Reference
 

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -10,7 +10,7 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 
 | Operation     | CLI command                          | Key flags                                               |
 | ------------- | ------------------------------------ | ------------------------------------------------------- |
-| `search pack` | `epismo pack search --type workflow` | `--query <keywords>` `--filter '{...}'` `--projects`    |
+| `search pack` | `epismo pack search --type workflow` | `--query <keywords>` `--filter '{...}'` `--projects` `--search-mode` |
 | `get pack`    | `epismo pack get <id>`               | `[--full]` `[--step-id <step-id-1>,<step-id-2>]`        |
 | `create pack` | `epismo pack create`                 | `--input @pack.json` or `--projects <ids>`              |
 | `update pack` | `epismo pack update <id>`            | `--input @changes.json` or `--projects <ids>`           |
@@ -38,6 +38,7 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 6. In search, pass `scopes:[{type:"personal"}, {type:"projects", ids:[...]}]` or use CLI `--personal --projects <ids>`.
 7. If `visibility` is omitted on pack create/update, default is `private`.
 8. Keep `query` compact: 2-6 domain keywords.
+9. `searchMode` defaults to `keyword`; pass `semantic` (CLI `--search-mode semantic`) to add vector similarity for intent-described queries. See [Epismo Basics — Search Ranking Mode](../../epismo-basics/SKILL.md#search-ranking-mode).
 
 ## Supported Filter Keys
 


### PR DESCRIPTION
## Summary

Documents the new `searchMode` parameter across the Epismo search skills, matching the CLI `--search-mode` flag and the MCP `searchMode` field.

`searchMode` selects the ranking mode: `keyword` (default) or `semantic` (keyword matching plus vector similarity).

## Changes

- `epismo-basics/SKILL.md`: new "Search Ranking Mode" section describing keyword vs semantic and when to use each.
- `project-tracking`, `workflow-pack`, `context-pack` `references/search.md`: add `--search-mode` to the operations key flags and a scope note linking back to epismo-basics. Corrects the context-pack wording that implied search was semantic by default (it is keyword by default; semantic is opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)