### PR TITLE
feat(project-tracking): document entry logs

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -49,7 +49,7 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 | `update suggestion`  | `epismo suggestion update <id> --title <t> --content <c>`                   |
 | `resolve suggestion` | `epismo suggestion resolve <id> --status <applied\|declined\|archived>`     |
 
-CLI forms shown; on MCP, derive the tool name mechanically (`pack get` → `epismo_pack_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
+CLI forms are terminal commands (`epismo ...`). On MCP, derive the tool name mechanically from the full command name (`epismo pack get` → `epismo_pack_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
 
 `<reference>` is any pack reference — an ID, `@alias`, share URL, or hub URL — resolved server-side. See [Pack References](../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
 

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -4,7 +4,7 @@ Discovery and loading patterns for context packs.
 For content templates, see [Content Templates](../templates/content.md).
 For visibility and sharing, see [Visibility & Sharing](./visibility.md).
 
-This reference shows CLI forms. Derive MCP tool names mechanically: spaces → underscores.
+This reference shows terminal CLI forms (`epismo ...`). Derive MCP tool names mechanically from the full command name: spaces and hyphens → underscores.
 Surface conventions are defined in [Context Pack](../SKILL.md#operations-context-packs).
 
 ## Surface Resolution

--- a/skills/epismo-basics/SKILL.md
+++ b/skills/epismo-basics/SKILL.md
@@ -42,7 +42,7 @@ epismo whoami                           # verify
 | `cli`   | `epismo <resource> <action> [--flags]` | `epismo pack search --type context` |
 | `mcp`   | `epismo_<resource>_<action>` + JSON    | `epismo_pack_search`                |
 
-MCP tool name = CLI command with spaces and hyphens replaced by underscores (e.g. `epismo pack get` → `epismo_pack_get`). Conceptual payloads are the same across surfaces; each `--kebab-flag` becomes a camelCase JSON key (`--include-snapshot` → `includeSnapshot`), and a repeatable / comma-separated flag becomes an array (`--status open,applied` → `statuses: ["open", "applied"]`). **Skill docs show CLI forms only** — derive the MCP tool and parameters from these rules rather than re-listing them per page.
+MCP tool name = the terminal CLI command name, including `epismo`, with spaces and hyphens replaced by underscores (e.g. `epismo pack get` → `epismo_pack_get`). Conceptual payloads are the same across surfaces; each `--kebab-flag` becomes a camelCase JSON key (`--include-snapshot` → `includeSnapshot`), and a repeatable / comma-separated flag becomes an array (`--status open,applied` → `statuses: ["open", "applied"]`). **Skill docs show CLI forms only** — derive the MCP tool and parameters from these rules rather than re-listing them per page.
 
 **CLI is the full surface; MCP is a subset.** Prefer MCP or CLI and ignore the HTTP API in normal use. Some surfaces are **CLI-only** (no `epismo_*` tool): `login` / `logout` / `whoami`, `workspace`, `project`, `agent`, `credit`, and `token` — use the CLI for these.
 

--- a/skills/epismo-basics/references/pack-alias.md
+++ b/skills/epismo-basics/references/pack-alias.md
@@ -30,9 +30,9 @@ Only the pack's **owner** may create or repoint an alias to it (in either the pe
 ## Access Options
 
 - **CLI** — the full surface (`upsert`, `get`, `list`, `delete`). Credentials from `epismo login` are used automatically.
-- **MCP** — the same four operations as `epismo_alias_*` tools (derive names mechanically; see [surface conventions](../SKILL.md#surface-conventions)). To fetch the pack itself, pass the reference to `epismo_pack_get`.
+- **MCP** — the same four operations as `epismo_alias_*` tools (derive names mechanically from the full CLI command name; see [surface conventions](../SKILL.md#surface-conventions)). To fetch the pack itself, pass the reference to `epismo_pack_get`.
 
-The CLI forms below apply to both surfaces.
+The operations below are shown as CLI commands; use the surface conventions above to call the same operations on MCP.
 
 ---
 

--- a/skills/epismo-basics/references/suggestions.md
+++ b/skills/epismo-basics/references/suggestions.md
@@ -80,4 +80,4 @@ epismo suggestion resolve <suggestion-id> --status applied
 
 `--status` accepts `open`, `applied`, `declined`, or `archived`.
 
-On MCP, derive the tool name mechanically (`suggestion list` → `epismo_suggestion_list`); flags become camelCase parameters and `--status open,applied` becomes `statuses: ["open", "applied"]`. See [surface conventions](../SKILL.md#surface-conventions).
+On MCP, derive the tool name mechanically from the full CLI command name (`epismo suggestion list` → `epismo_suggestion_list`); flags become camelCase parameters and `--status open,applied` becomes `statuses: ["open", "applied"]`. See [surface conventions](../SKILL.md#surface-conventions).

--- a/skills/project-tracking/SKILL.md
+++ b/skills/project-tracking/SKILL.md
@@ -24,11 +24,11 @@ Operate on tasks and goals in Epismo projects — from a quick status update to 
 | `update track` | `epismo track update <id> --input '<json>'`              |
 | `delete track` | `epismo track delete <id>`                               |
 | `apply track`  | `epismo track apply --input '<json>'`                    |
-| `create log`   | `epismo log create <track-id> --content '<text>'`   |
-| `list logs`    | `epismo log list [track-id] [--author-id <userId>]` |
-| `delete log`   | `epismo log delete <log-id>`                        |
+| `create log`   | `epismo log create <track-id> --content '<text>'`        |
+| `list logs`    | `epismo log list [track-id] [--author-id <userId>]`      |
+| `delete log`   | `epismo log delete <log-id>`                             |
 
-CLI forms shown; on MCP, derive the tool name mechanically (`track get` → `epismo_track_get`, `log create` → `epismo_log_create`, `log list` → `epismo_log_list`, `log delete` → `epismo_log_delete`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
+CLI forms are terminal commands (`epismo ...`). On MCP, derive the tool name mechanically from the full command name (`epismo track get` → `epismo_track_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
 
 For filter keys, status values, entity relationships, and search recipes, see [Search & Filter](./references/search.md).
 For when to append a log versus editing a track's own fields, see [Runbook — Logs](./references/runbook.md#logs).

--- a/skills/project-tracking/SKILL.md
+++ b/skills/project-tracking/SKILL.md
@@ -24,13 +24,14 @@ Operate on tasks and goals in Epismo projects — from a quick status update to 
 | `update track` | `epismo track update <id> --input '<json>'`              |
 | `delete track` | `epismo track delete <id>`                               |
 | `apply track`  | `epismo track apply --input '<json>'`                    |
-| `log track`    | `epismo track log <id> --content '<text>'`                |
-| `list logs`    | `epismo track logs <id>`                                  |
+| `create log`   | `epismo log create <track-id> --content '<text>'`   |
+| `list logs`    | `epismo log list [track-id] [--author-id <userId>]` |
+| `delete log`   | `epismo log delete <log-id>`                        |
 
-CLI forms shown; on MCP, derive the tool name mechanically (`track get` → `epismo_track_get`, `track log` → `epismo_track_log_create`, `track logs` → `epismo_track_log_list`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
+CLI forms shown; on MCP, derive the tool name mechanically (`track get` → `epismo_track_get`, `log create` → `epismo_log_create`, `log list` → `epismo_log_list`, `log delete` → `epismo_log_delete`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
 
 For filter keys, status values, entity relationships, and search recipes, see [Search & Filter](./references/search.md).
-For when to append an entry log versus editing a track's own fields, see [Runbook — Entry Logs](./references/runbook.md#entry-logs).
+For when to append a log versus editing a track's own fields, see [Runbook — Logs](./references/runbook.md#logs).
 
 ## Intent Router
 

--- a/skills/project-tracking/SKILL.md
+++ b/skills/project-tracking/SKILL.md
@@ -24,10 +24,13 @@ Operate on tasks and goals in Epismo projects — from a quick status update to 
 | `update track` | `epismo track update <id> --input '<json>'`              |
 | `delete track` | `epismo track delete <id>`                               |
 | `apply track`  | `epismo track apply --input '<json>'`                    |
+| `log track`    | `epismo track log <id> --content '<text>'`                |
+| `list logs`    | `epismo track logs <id>`                                  |
 
-CLI forms shown; on MCP, derive the tool name mechanically (`track get` → `epismo_track_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
+CLI forms shown; on MCP, derive the tool name mechanically (`track get` → `epismo_track_get`, `track log` → `epismo_track_log_create`, `track logs` → `epismo_track_log_list`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
 
 For filter keys, status values, entity relationships, and search recipes, see [Search & Filter](./references/search.md).
+For when to append an entry log versus editing a track's own fields, see [Runbook — Entry Logs](./references/runbook.md#entry-logs).
 
 ## Intent Router
 

--- a/skills/project-tracking/references/ai-delegation.md
+++ b/skills/project-tracking/references/ai-delegation.md
@@ -52,6 +52,8 @@ All six must pass before assigning AI-owned work. If any item fails, fix the gap
 3. **Create or update task** — write the task with all six checklist items satisfied. Include the expected output description in the task content.
 4. **Report** — confirm: title, assignee, expected output, done condition, and review timing.
 
+When the delegate finishes (or checks in partway through), append a `log track` entry on the task with `kind: "progress"` for a status check-in or `kind: "evaluation"` for a completion verdict against the done condition — see [Runbook — Entry Logs](./runbook.md#entry-logs). This keeps the acceptance-criteria trail on the task itself instead of only in chat, so a human reviewer can audit it later without re-deriving it.
+
 ## Failure Modes
 
 | Failure                           | Effect                                  | Prevention                                         |

--- a/skills/project-tracking/references/ai-delegation.md
+++ b/skills/project-tracking/references/ai-delegation.md
@@ -52,7 +52,7 @@ All six must pass before assigning AI-owned work. If any item fails, fix the gap
 3. **Create or update task** — write the task with all six checklist items satisfied. Include the expected output description in the task content.
 4. **Report** — confirm: title, assignee, expected output, done condition, and review timing.
 
-When the delegate finishes (or checks in partway through), append a `log track` entry on the task with `kind: "progress"` for a status check-in or `kind: "evaluation"` for a completion verdict against the done condition — see [Runbook — Entry Logs](./runbook.md#entry-logs). This keeps the acceptance-criteria trail on the task itself instead of only in chat, so a human reviewer can audit it later without re-deriving it.
+When the delegate finishes (or checks in partway through), append a `log create` entry on the task with `kind: "update"` for a status check-in or `kind: "review"` for a completion verdict against the done condition — see [Runbook — Logs](./runbook.md#logs). This keeps the acceptance-criteria trail on the task itself instead of only in chat, so a human reviewer can audit it later without re-deriving it.
 
 ## Failure Modes
 

--- a/skills/project-tracking/references/runbook.md
+++ b/skills/project-tracking/references/runbook.md
@@ -111,6 +111,22 @@ Use a non-UUID client label (e.g. `"t001"`) as `id` to create a new track. Use a
 }
 ```
 
+## Entry Logs
+
+Entry logs are an append-only comment/activity trail on a task or goal — separate from the track's own `title`/`content`/status fields. Use a log instead of a field edit when the information is a note *about* the track's history (evidence, a status-change rationale, an agent's progress update) rather than a change to its current state.
+
+- `log track` (`epismo track log <id> --content '<text>' [--kind comment|progress|evaluation|system]`) appends one immutable entry. `kind` defaults to `comment` — use `progress` for an agent's own activity updates and `evaluation` for a verdict or review result. Appending is free (no credit cost), so log liberally rather than saving everything for a final summary.
+- `list logs` (`epismo track logs <id> [--after <logId>]`) reads them back oldest first. Pass the previous response's `nextCursor` as `--after` to fetch only what's new since the last check.
+
+```json
+{
+  "kind": "progress",
+  "content": "Ran the migration against staging; 3 rows failed FK validation, investigating."
+}
+```
+
+Use a log to record *why* during [Operation Output](#operation-output) — e.g. append the **Evidence** line to the track itself when it should outlive the chat, in addition to reporting it. Do not use a log as a substitute for a real field update: if the track's status, assignee, or due date changed, that change belongs in `update track` / `apply track`, not buried in a log entry.
+
 ## Mode Playbooks
 
 ### 1) Partial Update

--- a/skills/project-tracking/references/runbook.md
+++ b/skills/project-tracking/references/runbook.md
@@ -111,16 +111,17 @@ Use a non-UUID client label (e.g. `"t001"`) as `id` to create a new track. Use a
 }
 ```
 
-## Entry Logs
+## Logs
 
-Entry logs are an append-only comment/activity trail on a task or goal — separate from the track's own `title`/`content`/status fields. Use a log instead of a field edit when the information is a note *about* the track's history (evidence, a status-change rationale, an agent's progress update) rather than a change to its current state.
+Logs are a comment/activity trail on a task or goal — separate from the track's own `title`/`content`/status fields. Use a log instead of a field edit when the information is a note *about* the track's history (evidence, a status-change rationale, an agent's progress update) rather than a change to its current state.
 
-- `log track` (`epismo track log <id> --content '<text>' [--kind comment|progress|evaluation|system]`) appends one immutable entry. `kind` defaults to `comment` — use `progress` for an agent's own activity updates and `evaluation` for a verdict or review result. Appending is free (no credit cost), so log liberally rather than saving everything for a final summary.
-- `list logs` (`epismo track logs <id> [--after <logId>]`) reads them back oldest first. Pass the previous response's `nextCursor` as `--after` to fetch only what's new since the last check.
+- `create log` (`epismo log create <track-id> --content '<text>' [--kind comment|update|review] [--idempotency-key <uuid>]`) appends one entry. `kind` defaults to `comment` — use `update` for activity/status updates and `review` for a verdict or review result. Appending is free (no credit cost), so log liberally rather than saving everything for a final summary.
+- `list logs` (`epismo log list [track-id] [--author-id <userId>] [--order desc|asc] [--cursor <logId>]`) reads logs newest first by default. Pass `track-id` to read one track's logs; omit it for a separate activity feed across *every* track you can currently access instead — `--author-id` narrows either way, e.g. to see "what's been happening" or "what has this user written." Pass the previous response's `nextCursor` back as `--cursor` with the same `--order` to fetch the next page; use `--order asc` for chronological replay. The cross-track feed (no `track-id`) reflects an ACL snapshot taken when each log was written, not a live re-check — a log you could see when it was written can still appear here after you lose access to that track, unlike a `track-id`-scoped read, which always reflects the track's live ACL.
+- `delete log` (`epismo log delete <log-id>`) deletes one log. Authors can delete their own logs; a track's creator can delete any log on that track. Deleted logs are omitted from future list results.
 
 ```json
 {
-  "kind": "progress",
+  "kind": "update",
   "content": "Ran the migration against staging; 3 rows failed FK validation, investigating."
 }
 ```

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -47,7 +47,7 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | `update suggestion`  | `epismo suggestion update <id> --title <t> --content <c>`                 |
 | `resolve suggestion` | `epismo suggestion resolve <id> --status <applied\|declined\|archived>`   |
 
-CLI forms shown; on MCP, derive the tool name mechanically (`pack get` → `epismo_pack_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
+CLI forms are terminal commands (`epismo ...`). On MCP, derive the tool name mechanically from the full command name (`epismo pack get` → `epismo_pack_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
 
 `<reference>` is any pack reference — an ID, `@alias`, share URL, or hub URL — resolved server-side. See [Pack References](../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
 

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -4,7 +4,7 @@ Discovery and loading patterns for workflow packs.
 For release and update decisions, see [Release](./release.md).
 For visibility and sharing, see [Visibility & Sharing](./visibility.md).
 
-This reference shows CLI forms. For surface conventions, see [Epismo Basics — Surface Conventions](../../epismo-basics/SKILL.md#surface-conventions).
+This reference shows terminal CLI forms (`epismo ...`). For MCP naming and parameters, see [Epismo Basics — Surface Conventions](../../epismo-basics/SKILL.md#surface-conventions).
 
 ## Operations
 


### PR DESCRIPTION
## Summary

Documents the new `epismo track log` / `epismo track logs` operations (append-only entry logs on tasks/goals) in the `project-tracking` skill:

- `SKILL.md` — operations table + MCP tool-name derivation, cross-reference to the new Runbook section.
- `references/runbook.md` — new **Entry Logs** section: when to log vs. edit a field, `kind` vocabulary, free-create billing, cursor-based `list logs`.
- `references/ai-delegation.md` — the delegation report step now points at logging a `progress`/`evaluation` entry so acceptance-criteria history survives on the task itself, not only in chat.

## Test plan

- Read through for consistency with the actual CLI/MCP contract (flag names, kind values, cursor field name).
- No tooling in this repo to lint/build against; changes are markdown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)