### PR TITLE
docs(pack): document pack outcome reporting and replace download filter

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -39,6 +39,7 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 | `update pack`        | `epismo pack update <reference> --input '<json>'`                           |
 | `delete pack`        | `epismo pack delete <reference>`                                            |
 | `like pack`          | `epismo pack like <reference> --liked`                                      |
+| `report pack`        | `epismo pack report <reference> --outcome success\|failure`                 |
 | `upsert alias`       | `epismo alias upsert @<name> --id <id>`                                     |
 | `get alias`          | `epismo alias get @<name>`                                                  |
 | `list aliases`       | `epismo alias list --type context`                                          |

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -50,7 +50,7 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 | `ownerId[]`        | string array      | Filter by owner user ID                                                                                      |
 | `category[]`       | enum array        | One or more categories — see [Visibility & Sharing — Category Reference](./visibility.md#category-reference) |
 | `minLikeCount`     | integer           | Minimum number of likes (useful for finding popular public guides)                                           |
-| `minDownloadCount` | integer           | Minimum number of imports                                                                                    |
+| `minSuccessCount`  | integer           | Minimum number of accounts reporting a successful run                                                        |
 | `updatedAtFrom`    | ISO-8601 datetime | Lower bound on last-updated timestamp                                                                        |
 | `updatedAtTo`      | ISO-8601 datetime | Upper bound on last-updated timestamp                                                                        |
 

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -37,6 +37,7 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | `update pack`  | `epismo pack update <reference> --input '<json>'`                               |
 | `delete pack`  | `epismo pack delete <reference>`                                                |
 | `like pack`    | `epismo pack like <reference> --liked`                                          |
+| `report pack`  | `epismo pack report <reference> --outcome success\|failure`                     |
 | `upsert alias` | `epismo alias upsert @<name> --id <id>`                                         |
 | `get alias`    | `epismo alias get @<name>`                                                      |
 | `list aliases` | `epismo alias list --type workflow`                                             |
@@ -110,6 +111,8 @@ epismo pack run @release-review \
 - The response returns `goal.id` and a `stepMap` (step id → track UUID). Fetch the whole run later with `epismo track search --type task --filter '{"goalId":["<goal-id>"]}'`.
 
 Use `epismo track apply` directly only when building a task tree from scratch without a pack.
+
+**After executing a pack** (via `pack run` or by following its steps inline), report the outcome: `epismo pack report <reference> --outcome success|failure`. Report `success` when the run achieved its objective, `failure` when it did not; do not report after merely reading a pack. One report per account — repeat reports overwrite the previous one (latest wins), so re-report after re-running. Reports power the hub's success counts and trending, and a `failure` is a good moment to file an improvement suggestion.
 
 Use [Workflow Patterns — Discovery](./templates/patterns.md#2-workflow-discovery) for structured adaptation reports.
 

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -45,7 +45,7 @@ This reference shows CLI forms. For surface conventions, see [Epismo Basics — 
 ### Workflows (`search pack`, type `workflow`)
 
 `category[]`, `visibility[]`, `like`, `ownerId[]`,
-`minLikeCount`, `minDownloadCount`, `updatedAtFrom`, `updatedAtTo`
+`minLikeCount`, `minSuccessCount`, `updatedAtFrom`, `updatedAtTo`
 
 ## Loading a Workflow
 


### PR DESCRIPTION
## Summary

The product replaced the ambiguous download counter with success/failure outcome reports (one report per account and pack, latest wins). This updates the skills to match:

- **Operation tables**: add `report pack` (`epismo pack report <reference> --outcome success|failure`) to the workflow-pack and context-pack skills.
- **Reporting convention** (workflow-pack): after executing a pack — via `pack run` or by following its steps inline — report the outcome. `success` when the run achieved its objective, `failure` when it did not; never report after merely reading a pack. Repeat reports overwrite the previous one, so re-report after re-running. A `failure` is a good moment to file an improvement suggestion.
- **Search references**: replace the removed `minDownloadCount` filter with `minSuccessCount` in both search docs.

## Context

Outcome reports are the marketplace's verified-use signal: they power the hub's success/failure counts and the trending ranking. Baking the reporting step into the skills makes it standard agent behavior rather than an optional courtesy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)