### PR TITLE
Update pack rating and project review guidance

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -39,7 +39,7 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 | `update pack`        | `epismo pack update <reference> --input '<json>'`                           |
 | `delete pack`        | `epismo pack delete <reference>`                                            |
 | `like pack`          | `epismo pack like <reference> --liked`                                      |
-| `report pack`        | `epismo pack report <reference> --outcome success\|failure`                 |
+| `rate pack`          | `epismo pack rate <reference> success\|failure`                             |
 | `upsert alias`       | `epismo alias upsert @<name> --reference <pack-reference>`                  |
 | `get alias`          | `epismo alias get @<name>`                                                  |
 | `list aliases`       | `epismo alias list --type context`                                          |

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -50,7 +50,7 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 | `ownerId[]`        | string array      | Filter by owner user ID                                                                                      |
 | `category[]`       | enum array        | One or more categories — see [Visibility & Sharing — Category Reference](./visibility.md#category-reference) |
 | `minLikeCount`     | integer           | Minimum number of likes (useful for finding popular public guides)                                           |
-| `minSuccessCount`  | integer           | Minimum number of accounts reporting a successful run                                                        |
+| `minSuccessCount`  | integer           | Minimum number of accounts whose latest outcome for the pack is success                                       |
 | `updatedAtFrom`    | ISO-8601 datetime | Lower bound on last-updated timestamp                                                                        |
 | `updatedAtTo`      | ISO-8601 datetime | Upper bound on last-updated timestamp                                                                        |
 

--- a/skills/project-tracking/SKILL.md
+++ b/skills/project-tracking/SKILL.md
@@ -16,18 +16,18 @@ Operate on tasks and goals in Epismo projects — from a quick status update to 
 
 ## Operations
 
-| Operation      | CLI                                                               |
-| -------------- | ----------------------------------------------------------------- |
-| `search track` | `epismo track search --type task\|goal --filter '{...}'`          |
-| `get track`    | `epismo track get <track-reference>`                              |
-| `create track` | `epismo track create --input '<json>'`                            |
-| `update track` | `epismo track update <track-reference> --input '<json>'`          |
-| `delete track` | `epismo track delete <track-reference>`                           |
-| `apply track`  | `epismo track apply --input '<json>'`                             |
+| Operation      | CLI                                                                 |
+| -------------- | ------------------------------------------------------------------- |
+| `search track` | `epismo track search --type task\|goal --filter '{...}'`            |
+| `get track`    | `epismo track get <track-reference>`                                |
+| `create track` | `epismo track create --input '<json>'`                              |
+| `update track` | `epismo track update <track-reference> --input '<json>'`            |
+| `delete track` | `epismo track delete <track-reference>`                             |
+| `apply track`  | `epismo track apply --input '<json>'`                               |
 | `review track` | `epismo track review <track-reference...> [--instruction '<text>']` |
-| `create log`   | `epismo log create <track-reference> --content '<text>'`          |
-| `list logs`    | `epismo log list [track-reference] [--author-id <userId>]`        |
-| `delete log`   | `epismo log delete <log-id>`                                      |
+| `create log`   | `epismo log create <track-reference> --content '<text>'`            |
+| `list logs`    | `epismo log list [track-reference] [--author-id <userId>]`          |
+| `delete log`   | `epismo log delete <log-id>`                                        |
 
 CLI forms are terminal commands (`epismo ...`). On MCP, derive the tool name mechanically from the full command name (`epismo track get` → `epismo_track_get`). See [surface conventions](../epismo-basics/SKILL.md#surface-conventions).
 
@@ -42,7 +42,7 @@ For when to append a log versus editing a track's own fields, see [Runbook — L
 | Add one new item                  | Exactly one task or goal; existing structure is valid                                     | 3 Coordinate — New Item             | [Runbook](./references/runbook.md#2-new-item-creation)            |
 | Plan multiple items or a new goal | New goal structure, multi-step plan, or batch creation                                    | 2 Plan → 3 Coordinate — Large-Scale | [Runbook](./references/runbook.md#3-large-scale-planning)         |
 | Unblock or rebalance              | Stalled queue, overloaded assignee, dependency bottleneck, noisy backlog                  | 4 Risk → 3 Coordinate — Recovery    | [Runbook](./references/runbook.md#4-recovery-and-backlog-hygiene) |
-| Extract learning                  | Task is done, goal is completed/postponed, or user asks what should become reusable       | 3 Coordinate — Learning Review      | [Runbook](./references/runbook.md#learning-reviews)               |
+| Extract learning                  | Task is done, goal is completed/postponed, or user asks what should become reusable       | 3 Coordinate — Review               | [Runbook](./references/runbook.md#learning-reviews)               |
 | Design an AI-owned task           | Delegating work to an AI agent with clear acceptance criteria                             | 3 Coordinate + AI Delegation        | [AI Delegation](./references/ai-delegation.md)                    |
 | Unclear intent                    | Cannot confidently match any row above                                                    | 1 Intake — ask once                 | —                                                                 |
 

--- a/skills/project-tracking/references/runbook.md
+++ b/skills/project-tracking/references/runbook.md
@@ -113,10 +113,10 @@ Use a non-UUID client label (e.g. `"t001"`) as `id` to create a new track. Use a
 
 ## Logs
 
-Logs are a comment/activity trail on a task or goal — separate from the track's own `title`/`content`/status fields. Use a log instead of a field edit when the information is a note *about* the track's history (evidence, a status-change rationale, an agent's progress update) rather than a change to its current state.
+Logs are a comment/activity trail on a task or goal — separate from the track's own `title`/`content`/status fields. Use a log instead of a field edit when the information is a note _about_ the track's history (evidence, a status-change rationale, an agent's progress update) rather than a change to its current state.
 
 - `create log` (`epismo log create <track-reference> --content '<text>' [--kind comment|update|review] [--idempotency-key <uuid>]`) appends one entry. `kind` defaults to `comment` — use `update` for activity/status updates and `review` for a verdict or review result. Appending is free (no credit cost), so log liberally rather than saving everything for a final summary.
-- `list logs` (`epismo log list [track-reference] [--author-id <userId>] [--order desc|asc] [--cursor <logId>]`) reads logs newest first by default. Pass `track-reference` to read one track's logs; omit it for a separate activity feed across *every* track you can currently access instead — `--author-id` narrows either way, e.g. to see "what's been happening" or "what has this user written." Pass the previous response's `nextCursor` back as `--cursor` with the same `--order` to fetch the next page; use `--order asc` for chronological replay. The cross-track feed (no `track-reference`) reflects an ACL snapshot taken when each log was written, not a live re-check — a log you could see when it was written can still appear here after you lose access to that track, unlike a `track-reference`-scoped read, which always reflects the track's live ACL.
+- `list logs` (`epismo log list [track-reference] [--author-id <userId>] [--order desc|asc] [--cursor <logId>]`) reads logs newest first by default. Pass `track-reference` to read one track's logs; omit it for a separate activity feed across _every_ track you can currently access instead — `--author-id` narrows either way, e.g. to see "what's been happening" or "what has this user written." Pass the previous response's `nextCursor` back as `--cursor` with the same `--order` to fetch the next page; use `--order asc` for chronological replay. The cross-track feed (no `track-reference`) reflects an ACL snapshot taken when each log was written, not a live re-check — a log you could see when it was written can still appear here after you lose access to that track, unlike a `track-reference`-scoped read, which always reflects the track's live ACL.
 - `delete log` (`epismo log delete <log-id>`) deletes one log. Authors can delete their own logs; a track's creator can delete any log on that track. Deleted logs are omitted from future list results.
 
 ```json
@@ -126,11 +126,11 @@ Logs are a comment/activity trail on a task or goal — separate from the track'
 }
 ```
 
-Use a log to record *why* during [Operation Output](#operation-output) — e.g. append the **Evidence** line to the track itself when it should outlive the chat, in addition to reporting it. Do not use a log as a substitute for a real field update: if the track's status, assignee, or due date changed, that change belongs in `update track` / `apply track`, not buried in a log entry.
+Use a log to record _why_ during [Operation Output](#operation-output) — e.g. append the **Evidence** line to the track itself when it should outlive the chat, in addition to reporting it. Do not use a log as a substitute for a real field update: if the track's status, assignee, or due date changed, that change belongs in `update track` / `apply track`, not buried in a log entry.
 
-## Learning Reviews
+## Reviews
 
-Learning Reviews turn completed or postponed work into reusable learning without saving anything automatically.
+Reviews turn completed or postponed work into reusable learning without saving anything automatically.
 
 Use `review track` when:
 
@@ -148,11 +148,11 @@ The command reads one or more target tasks/goals, related tracks, logs, and sour
 
 Decision guide:
 
-| Review output says...                    | Follow-up operation                                                       |
-| ---------------------------------------- | ------------------------------------------------------------------------- |
-| New reusable pattern                     | Hand off to Workflow Pack or Context Pack creation                        |
-| User-owned source pack should change     | Use `update pack` through the relevant pack skill                         |
-| Someone else's source pack should change | Use `create suggestion` through the relevant pack skill                   |
+| Review output says...                    | Follow-up operation                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| New reusable pattern                     | Hand off to Workflow Pack or Context Pack creation                         |
+| User-owned source pack should change     | Use `update pack` through the relevant pack skill                          |
+| Someone else's source pack should change | Use `create suggestion` through the relevant pack skill                    |
 | Useful note but not reusable yet         | Report it; optionally append a `review` log if it should stay on the track |
 
 Review output should use the primary language of the seed knowledge base content and logs. If mixed, it follows the target task/goal language.

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -114,7 +114,7 @@ Use `epismo track apply` directly only when building a task tree from scratch wi
 
 **After using a pack** (via `pack run` or by following its steps inline), rate its outcome with `epismo pack rate <reference> success|failure`. Use `success` when the pack helped achieve the objective and `failure` when it did not; do not rate after merely reading a pack. One outcome per account — repeating the command updates the previous outcome (latest wins). Rated outcomes power the hub's success/failure counts and trending, and `failure` is a good moment to file an improvement suggestion.
 
-If execution produced tasks/goals, run a Learning Review from [Project Tracking](../project-tracking/references/runbook.md#learning-reviews) before creating or updating a workflow pack. Pass related completed/postponed tasks or goals together when they belong to the same execution outcome. Review output is read-only; use it as evidence for `create pack`, `update pack`, or `create suggestion`, not as an automatic write.
+If execution produced tasks/goals, run a review from [Project Tracking](../project-tracking/references/runbook.md#reviews) before creating or updating a workflow pack. Pass related completed/postponed tasks or goals together when they belong to the same execution outcome. Review output is read-only; use it as evidence for `create pack`, `update pack`, or `create suggestion`, not as an automatic write.
 
 Use [Workflow Patterns — Discovery](./templates/patterns.md#2-workflow-discovery) for structured adaptation reports.
 

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -37,7 +37,7 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | `update pack`        | `epismo pack update <reference> --input '<json>'`                       |
 | `delete pack`        | `epismo pack delete <reference>`                                        |
 | `like pack`          | `epismo pack like <reference> --liked`                                  |
-| `report pack`        | `epismo pack report <reference> --outcome success\|failure`             |
+| `rate pack`          | `epismo pack rate <reference> success\|failure`                         |
 | `upsert alias`       | `epismo alias upsert @<name> --reference <pack-reference>`              |
 | `get alias`          | `epismo alias get @<name>`                                              |
 | `list aliases`       | `epismo alias list --type workflow`                                     |
@@ -112,7 +112,7 @@ epismo pack run @release-review \
 
 Use `epismo track apply` directly only when building a task tree from scratch without a pack.
 
-**After executing a pack** (via `pack run` or by following its steps inline), report the outcome: `epismo pack report <reference> --outcome success|failure`. Report `success` when the run achieved its objective, `failure` when it did not; do not report after merely reading a pack. One report per account — repeat reports overwrite the previous one (latest wins), so re-report after re-running. Reports power the hub's success counts and trending, and a `failure` is a good moment to file an improvement suggestion.
+**After using a pack** (via `pack run` or by following its steps inline), rate its outcome with `epismo pack rate <reference> success|failure`. Use `success` when the pack helped achieve the objective and `failure` when it did not; do not rate after merely reading a pack. One outcome per account — repeating the command updates the previous outcome (latest wins). Rated outcomes power the hub's success/failure counts and trending, and `failure` is a good moment to file an improvement suggestion.
 
 If execution produced tasks/goals, run a Learning Review from [Project Tracking](../project-tracking/references/runbook.md#learning-reviews) before creating or updating a workflow pack. Pass related completed/postponed tasks or goals together when they belong to the same execution outcome. Review output is read-only; use it as evidence for `create pack`, `update pack`, or `create suggestion`, not as an automatic write.
 

--- a/skills/workflow-pack/references/quality.md
+++ b/skills/workflow-pack/references/quality.md
@@ -9,7 +9,7 @@ For visibility and approval rules, see [Visibility & Sharing](./visibility.md).
 
 All criteria must pass. A single fail means: fix the issue or keep the workflow private.
 
-1. **Proven execution** — at least one real execution path with observable outcome (tracks or linked records with identifiers), OR seed-source evidence (blog/docs/design rationale) with explicit assumptions and limits. Prefer including a Learning Review from the completed/postponed task or goal when available; pass multiple related targets together when they represent one execution outcome.
+1. **Proven execution** — at least one real execution path with observable outcome (tracks or linked records with identifiers), OR seed-source evidence (blog/docs/design rationale) with explicit assumptions and limits. Prefer including a review from the completed/postponed task or goal when available; pass multiple related targets together when they represent one execution outcome.
    Fail: outcome claimed but no records, links, or rationale provided.
 2. **Reusability** — steps avoid project-specific names, IDs, and one-off constraints.
    Fail: steps reference specific team members, internal URLs, or non-generalizable configurations.


### PR DESCRIPTION
## Summary

- replace pack outcome reporting instructions with `pack rate <reference> success|failure`
- clarify that repeated ratings update the account latest outcome
- align project-tracking and workflow-pack guidance with the current review terminology and anchors

## Scope

- context-pack guidance
- project-tracking guidance and runbook
- workflow-pack guidance and quality criteria