### PR TITLE
Align Epismo skills with current product surfaces

### DIFF
--- a/skills/context-pack/SKILL.md
+++ b/skills/context-pack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-pack
-description: "Pack, share, and load context using Epismo context packs. Trigger on: 'pack this', 'new pack', 'get <id>', 'read <alias>', 'load my context', 'what context do I have', 'restore session', 'save this context', 'share with my team', 'pack this up', 'hand this off', 'publish this guide', 'organize my packs', 'suggest a change to a pack', 'review suggestions', 'resolve a suggestion', or any intent to persist or retrieve knowledge across tools or sessions."
+description: "Pack, share, and load context using Epismo context packs. Trigger on: 'pack this', 'new pack', 'get by ID', 'read an alias', 'load my context', 'what context do I have', 'restore session', 'save this context', 'share with my team', 'pack this up', 'hand this off', 'publish this guide', 'organize my packs', 'suggest a change to a pack', 'review suggestions', 'resolve a suggestion', or any intent to persist or retrieve knowledge across tools or sessions."
 ---
 
 # Context Pack
@@ -34,7 +34,7 @@ The unit of organization is a **block** inside a pack. The goal is one well-stru
 | Operation            | CLI                                                                         |
 | -------------------- | --------------------------------------------------------------------------- |
 | `search pack`        | `epismo pack search --type context [--query <keywords>] [--filter '{...}']` |
-| `get pack`           | `epismo pack get <reference> [--full] [--block-id <id>]`                    |
+| `get pack`           | `epismo pack get <reference> [--full] [--block-id <id>] [--share-url]`      |
 | `create pack`        | `epismo pack create --input '<json>'`                                       |
 | `update pack`        | `epismo pack update <reference> --input '<json>'`                           |
 | `delete pack`        | `epismo pack delete <reference>`                                            |
@@ -227,11 +227,11 @@ Confirm with user, then `create pack`:
 }
 ```
 
-Return ID, title, and share URL. A share URL can be passed straight back to `pack get` as a `reference`; see [Epismo Basics — Pack References](../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
+After creation succeeds, request the share URL explicitly with `epismo pack get <context-id> --share-url`, then return ID, title, and the returned `shareUrl`. On MCP, call `epismo_pack_get` with `shareUrl: true`. A share URL can be passed straight back to `pack get` as a `reference`; see [Epismo Basics — Pack References](../epismo-basics/SKILL.md#pack-references-resolving-share-urls).
 
 ```
 context  <context-id>  <context-title>
-share    https://epismo.ai/hub/contexts/<id>
+share    https://epismo.ai/share/<token>
 ```
 
 ---

--- a/skills/context-pack/references/search.md
+++ b/skills/context-pack/references/search.md
@@ -12,7 +12,7 @@ Surface conventions are defined in [Context Pack](../SKILL.md#operations-context
 | Operation     | CLI command                         | Key flags                                               |
 | ------------- | ----------------------------------- | ------------------------------------------------------- |
 | `search pack` | `epismo pack search --type context` | `--query <keywords>` `--filter '{...}'` `--projects` `--search-mode` |
-| `get pack`    | `epismo pack get <id>`              | `[--full]` `[--block-id <block-id>]`                    |
+| `get pack`    | `epismo pack get <id>`              | `[--full]` `[--block-id <block-id>]` `[--share-url]`    |
 | `like pack`   | `epismo pack like <id> --liked`     | `--no-liked` to remove                                  |
 
 ## Quick Reference

--- a/skills/context-pack/references/visibility.md
+++ b/skills/context-pack/references/visibility.md
@@ -90,7 +90,13 @@ The Epismo share URL format is:
 https://epismo.ai/share/{token}
 ```
 
-Obtain the share token from the create/update response or from the Epismo UI. The token resolves to a redirect at:
+After creating or updating the pack, create or retrieve its share URL explicitly:
+
+```bash
+epismo pack get <reference> --share-url
+```
+
+The response includes `shareUrl`. On MCP, call `epismo_pack_get` with `shareUrl: true`. Pack create/update responses do not generate a share link automatically. Requesting a link does not make a private pack public; recipients still need access. The share token resolves to a redirect at:
 
 ```
 https://epismo.ai/hub/contexts/{pack-id}

--- a/skills/epismo-basics/SKILL.md
+++ b/skills/epismo-basics/SKILL.md
@@ -46,6 +46,8 @@ MCP tool name = the terminal CLI command name, including `epismo`, with spaces a
 
 **CLI is the full surface; MCP is a subset.** Prefer MCP or CLI and ignore the HTTP API in normal use. Some surfaces are **CLI-only** (no `epismo_*` tool): `login` / `logout` / `whoami`, `workspace`, `project`, `agent`, `credit`, and `token` — use the CLI for these.
 
+Project containers can be listed, created, and updated through the CLI and HTTP API. Project deletion or deactivation is not available on either surface; use the web app for project lifecycle management.
+
 ### Pack Aliases
 
 Packs can be fetched by a short alias instead of a full ID. On the CLI, pass the alias (with or without `@` prefix) as the positional `<reference>` to `pack get` — same slot the ID goes in. In MCP, pass it via the `reference` parameter. To create and manage aliases, see [Pack Alias](./references/pack-alias.md).
@@ -70,6 +72,16 @@ epismo workspace current                              # show saved default (no n
 ```
 
 Workspace selection is CLI-only. All CLI commands resolve workspace automatically from `EPISMO_TOKEN`, saved default, then personal space. In MCP, workspace scope is implicit in the OAuth token.
+
+### Member Mutation Results
+
+`epismo workspace member upsert/delete` and `epismo project member add/delete` return one result per input position plus an authoritative `memberCount`. Single-target deletes use the same transactional bulk operation. Always inspect every result; command success does not mean every target changed.
+
+- Workspace upsert statuses: `added`, `updated`, `unchanged`, `skipped`, `failed`.
+- Project add statuses: `added`, `unchanged`, `skipped`, `failed`.
+- Workspace member/project member delete statuses: `deleted`, `skipped`, `failed`.
+- Use `code` to explain non-changing outcomes such as `ALREADY_MEMBER`, `DUPLICATE_INPUT`, `USER_NOT_FOUND`, `MEMBER_NOT_FOUND`, `ROLE_NOT_ALLOWED`, or `NOT_WORKSPACE_MEMBER`.
+- Treat `inputIndex` as the mapping back to the original user ID list, including duplicate positions.
 
 ---
 
@@ -109,6 +121,14 @@ Pack-level commands (`get`, `update`, `like`, `delete`) take a **single `referen
 
 - **CLI** — positional `<reference>`: `epismo pack get <reference>`.
 - **MCP** — `reference` parameter on the `epismo_pack_*` tools.
+
+Create or retrieve a share URL only when it is needed:
+
+```bash
+epismo pack get <reference> --share-url
+```
+
+On MCP, call `epismo_pack_get` with `shareUrl: true`. A successful response includes `shareUrl`. Pack create/update responses do not generate share links automatically. Requesting a share URL does not make a private pack public; recipients still need access to private packs.
 
 Share URLs resolve server-side by token, independent of host — a workspace-subdomain share URL works without special handling, and no credentials or redirect-following are needed. The resolved pack type (`workflow` / `context`) comes back in the response.
 

--- a/skills/project-tracking/SKILL.md
+++ b/skills/project-tracking/SKILL.md
@@ -42,7 +42,7 @@ For when to append a log versus editing a track's own fields, see [Runbook — L
 | Add one new item                  | Exactly one task or goal; existing structure is valid                                     | 3 Coordinate — New Item             | [Runbook](./references/runbook.md#2-new-item-creation)            |
 | Plan multiple items or a new goal | New goal structure, multi-step plan, or batch creation                                    | 2 Plan → 3 Coordinate — Large-Scale | [Runbook](./references/runbook.md#3-large-scale-planning)         |
 | Unblock or rebalance              | Stalled queue, overloaded assignee, dependency bottleneck, noisy backlog                  | 4 Risk → 3 Coordinate — Recovery    | [Runbook](./references/runbook.md#4-recovery-and-backlog-hygiene) |
-| Extract learning                  | Task is done, goal is completed/postponed, or user asks what should become reusable       | 3 Coordinate — Review               | [Runbook](./references/runbook.md#learning-reviews)               |
+| Extract learning                  | Task is done, goal is completed/postponed, or user asks what should become reusable       | 3 Coordinate — Review               | [Runbook](./references/runbook.md#reviews)                        |
 | Design an AI-owned task           | Delegating work to an AI agent with clear acceptance criteria                             | 3 Coordinate + AI Delegation        | [AI Delegation](./references/ai-delegation.md)                    |
 | Unclear intent                    | Cannot confidently match any row above                                                    | 1 Intake — ask once                 | —                                                                 |
 
@@ -70,7 +70,7 @@ Pick one execution mode from [Runbook — Mode Selector](./references/runbook.md
 
 When a task status changes to `done`, run a downstream dependents check: query `dependsOn=["<task-id>"]` and report what is now unblocked.
 
-When a task reaches `done` or a goal reaches `completed` / `postponed`, check the update response for `learningReview`. If the user asks for deeper learning or the lightweight review suggests reusable guidance, run `review track` for the relevant task or goal. If several completed/postponed items belong to the same outcome, pass them together so the review can compare cross-target patterns. Treat the result as read-only: create/update packs or create suggestions only through explicit follow-up operations.
+When a task reaches `done` or a goal reaches `completed` / `postponed`, check the update response for `review`. If the user asks for deeper learning or the lightweight review suggests reusable guidance, run `review track` for the relevant task or goal. If several completed/postponed items belong to the same outcome, pass them together so the review can compare cross-target patterns. Treat the result as read-only: create/update packs or create suggestions only through explicit follow-up operations.
 
 Operational state lives in tracks. Use workflow packs only when the structure should be reused beyond the current execution context — see [Workflow Pack](../workflow-pack/SKILL.md).
 

--- a/skills/project-tracking/references/runbook.md
+++ b/skills/project-tracking/references/runbook.md
@@ -155,7 +155,7 @@ Decision guide:
 | Someone else's source pack should change | Use `create suggestion` through the relevant pack skill                    |
 | Useful note but not reusable yet         | Report it; optionally append a `review` log if it should stay on the track |
 
-Review output should use the primary language of the seed knowledge base content and logs. If mixed, it follows the target task/goal language.
+Review output should use the primary language of the seed entry content and logs. If mixed, it follows the target task/goal language.
 
 ## Mode Playbooks
 

--- a/skills/project-tracking/references/search.md
+++ b/skills/project-tracking/references/search.md
@@ -23,7 +23,7 @@ For reusable workflow discovery, see [Workflow Pack — Search & Discovery](../.
 | Tasks in progress             | `status=["in_progress"]`                                                                |
 | Tasks due soon                | `status=["backlog","todo","in_progress"]` + `dueDateTo=<date>`                          |
 | Blocked tasks                 | `status=["backlog","todo","in_progress"]` → check each `dependsOn[]` for non-`done`     |
-| Recently completed tasks      | `status=["done"]` + `doneAtFrom=<now-7d>`                                               |
+| Recently completed tasks      | `status=["done"]` + `updatedAtFrom=<now-7d>`                                            |
 | Tasks under a goal            | `goalId=["<goal-id>"]`                                                                  |
 | Downstream dependents         | `dependsOn=["<task-id>"]` — finds what unblocks when this task completes                |
 | Post-completion unblock check | Set task to `done` → query `dependsOn=["<task-id>"]` → re-check remaining prerequisites |
@@ -53,15 +53,15 @@ For reusable workflow discovery, see [Workflow Pack — Search & Discovery](../.
 ## Date/Time Semantics
 
 1. `dueDateFrom` / `dueDateTo` — date-only, normalized to UTC midnight.
-2. All other datetime filters (`updatedAtFrom/To`, `doneAtFrom/To`) — keep provided ISO-8601 precision.
-3. `task.doneAt` is read-only (system-managed) but searchable via `doneAtFrom/To`.
+2. `updatedAtFrom` / `updatedAtTo` — keep provided ISO-8601 precision.
+3. Completed-task period queries use `status=["done"]` with `updatedAtFrom` / `updatedAtTo`.
 
 ## Supported Filter Keys
 
 ### Tasks (`search track`, type `task`)
 
 `status[]`, `assignee[]`, `goalId[]`, `parentId[]`, `dependsOn[]`,
-`dueDateFrom`, `dueDateTo`, `updatedAtFrom`, `updatedAtTo`, `doneAtFrom`, `doneAtTo`
+`dueDateFrom`, `dueDateTo`, `updatedAtFrom`, `updatedAtTo`
 
 ### Goals (`search track`, type `goal`)
 
@@ -111,9 +111,9 @@ These are computed from entity data, not stored as status field values. Use them
 
 ### Throughput — completed in last 7 days
 
-- `status=["done"]` + `doneAtFrom=<now-7d>` + `doneAtTo=<now>`
+- `status=["done"]` + `updatedAtFrom=<now-7d>` + `updatedAtTo=<now>`
 
 ### Release evidence — completed work in a period
 
-- Tasks: `status=["done"]` + `doneAtFrom=<iso8601>` + optional `scopes=[{type:"projects", ids:["<project-id>"]}]`
+- Tasks: `status=["done"]` + `updatedAtFrom=<iso8601>` + optional `scopes=[{type:"projects", ids:["<project-id>"]}]`
 - Goals: `status=["completed"]` + `updatedAtFrom=<iso8601>` + optional `scopes=[{type:"projects", ids:["<project-id>"]}]`

--- a/skills/workflow-pack/SKILL.md
+++ b/skills/workflow-pack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-pack
-description: "Discover, reuse, and release workflow packs in Epismo. Trigger on: 'find a workflow', 'get <id>', 'read <alias>', 'new workflow', 'create workflow', 'capture pattern', 'adapt a workflow', 'reuse this pattern', 'update workflow', 'organize steps', 'release this as a workflow', 'publish a workflow', 'deprecate workflow', 'suggest a change to a workflow', 'review suggestions', 'resolve a suggestion', or any intent to search community workflows or capture a proven execution pattern for reuse."
+description: "Discover, reuse, and release workflow packs in Epismo. Trigger on: 'find a workflow', 'get by ID', 'read an alias', 'new workflow', 'create workflow', 'capture pattern', 'adapt a workflow', 'reuse this pattern', 'update workflow', 'organize steps', 'release this as a workflow', 'publish a workflow', 'deprecate workflow', 'suggest a change to a workflow', 'review suggestions', 'resolve a suggestion', or any intent to search community workflows or capture a proven execution pattern for reuse."
 ---
 
 # Workflow Pack
@@ -32,7 +32,7 @@ Discover, adapt, and release reusable workflow packs in Epismo — from finding 
 | Operation            | CLI                                                                     |
 | -------------------- | ----------------------------------------------------------------------- |
 | `search pack`        | `epismo pack search --type workflow --filter '{...}'`                   |
-| `get pack`           | `epismo pack get <reference> [--full] [--step-id <ids>]`                |
+| `get pack`           | `epismo pack get <reference> [--full] [--step-id <ids>] [--share-url]`  |
 | `create pack`        | `epismo pack create --input '<json>'`                                   |
 | `update pack`        | `epismo pack update <reference> --input '<json>'`                       |
 | `delete pack`        | `epismo pack delete <reference>`                                        |
@@ -310,9 +310,15 @@ Run the pre-decision checks in [Release](./references/release.md) before choosin
 
 See [Release](./references/release.md) for the approval boundary and required output format.
 
+After the create/update succeeds, request the share URL explicitly:
+
+```bash
+epismo pack get <workflow-id> --share-url
+```
+
 ```
 workflow  <workflow-id>  <workflow-title>
-share     https://epismo.ai/hub/workflows/<id>
+share     https://epismo.ai/share/<token>
 ```
 
 ---

--- a/skills/workflow-pack/references/search.md
+++ b/skills/workflow-pack/references/search.md
@@ -11,7 +11,7 @@ This reference shows terminal CLI forms (`epismo ...`). For MCP naming and param
 | Operation     | CLI command                          | Key flags                                               |
 | ------------- | ------------------------------------ | ------------------------------------------------------- |
 | `search pack` | `epismo pack search --type workflow` | `--query <keywords>` `--filter '{...}'` `--projects` `--search-mode` |
-| `get pack`    | `epismo pack get <id>`               | `[--full]` `[--step-id <step-id-1>,<step-id-2>]`        |
+| `get pack`    | `epismo pack get <id>`               | `[--full]` `[--step-id <step-id-1>,<step-id-2>]` `[--share-url]` |
 | `create pack` | `epismo pack create`                 | `--input @pack.json` or `--projects <ids>`              |
 | `update pack` | `epismo pack update <id>`            | `--input @changes.json` or `--projects <ids>`           |
 | `delete pack` | `epismo pack delete <id>`            | —                                                       |

--- a/skills/workflow-pack/references/visibility.md
+++ b/skills/workflow-pack/references/visibility.md
@@ -72,7 +72,13 @@ After publishing, deliver to the intended audience via share URL.
 
 ### Share URL
 
-Obtain the share URL from the create or update response or the Epismo UI and hand it to the recipient. To open it yourself, pass the whole URL as the `reference` to `pack get` — it resolves server-side, no token extraction needed.
+After creating or updating the pack, create or retrieve its share URL explicitly:
+
+```bash
+epismo pack get <reference> --share-url
+```
+
+The response includes `shareUrl`. On MCP, call `epismo_pack_get` with `shareUrl: true`. Requesting a link does not make a private pack public; recipients still need access. To open the link yourself, pass the whole URL as the `reference` to `pack get` — it resolves server-side, no token extraction needed.
 
 See [Epismo Basics — Pack References](../../epismo-basics/SKILL.md#pack-references-resolving-share-urls) for all accepted reference forms.
 


### PR DESCRIPTION
## Summary

- document project lifecycle limits and authoritative member mutation results
- update context and workflow skills to retrieve share URLs explicitly
- align track review terminology and supported search filters
- clarify pack reference triggers and visibility guidance

## Testing

- `git diff --check`