### PR TITLE
Document Draft as a mutable, unpublished Playbook content model

### DIFF
--- a/skills/epismo/SKILL.md
+++ b/skills/epismo/SKILL.md
@@ -10,6 +10,7 @@ Keep reusable guidance separate from real execution:
 - **Playbook** is a logical, access-controlled container with immutable Versions.
 - **Version** contains the Definition: title, description, category, input schema, and Steps.
 - **Step** is guidance, not execution state. It has no status, assignee, transition, or completion.
+- **Draft** is the mutable, unpublished content of a Playbook. Saving it never mints a Version; publishing it does, and discards the Draft.
 - **Case** is one real matter, either pinned to a Version or ad hoc.
 - **Task** materializes only work that needs explicit ownership or review.
 - **Record** is append-only shared output, decision, note, review, handoff, or activity.
@@ -54,7 +55,7 @@ Do not create a Case merely to read a Playbook. Do not turn every Step into a Ta
 - In MCP, read the `epismo://context/current_user` resource to resolve identity before a write, `epismo://context/users` before assigning a Case or Task, and `epismo://context/projects` before constructing an ACL. In the CLI, use `epismo whoami` and the workspace/project listing commands for the same purpose.
 - CLI is the full authoring and administration surface. Successful commands emit JSON to stdout; failures emit structured errors to stderr.
 - Keep one identity and workspace throughout a connected operation. With EPISMO_TOKEN, the token's workspace overrides the saved CLI default.
-- Every mutation takes a fresh UUID idempotency key. Reuse a key only when retrying the identical uncertain request; a reused key with different arguments is rejected.
+- Every mutation takes a fresh UUID idempotency key, except saving a Draft, which uses `baseRevision` instead — the revision last read, or `0` for a first Draft. Reuse an idempotency key only when retrying the identical uncertain request; a reused key with different arguments is rejected. Send a stale `baseRevision` and the save is rejected the same way — re-read the Draft and retry.
 - Identifiers are UUIDs, except Step IDs, which are four characters of `A-Z0-9`. Page sizes cap at 100.
 - Retry only transient failures. For Case and Task mutations, re-read after a lock conflict and reconsider the intent. Never replay stale intent by changing only the lock version.
 
@@ -65,6 +66,7 @@ An ACL is an explicit list of Account UUIDs, Project UUIDs, and — for Playbook
 Access separates read from write:
 
 - Playbook reads follow the Playbook ACL or a valid share token. Publishing, ACL changes, archival, aliases, and share tokens require rights over the owner Account.
+- Draft reads follow the Playbook ACL, not a share token — there is no token-based path to unpublished content. Saving, discarding, and publishing a Draft require rights over the owner Account, the same as publishing a Version directly.
 - Case, Task, and Record reads follow the current Case ACL. Task and Record have no ACL of their own.
 - Case writes require being the Case starter or its current assignee. ACL membership alone is read access, so plan ownership before delegating.
 

--- a/skills/epismo/references/author-playbooks.md
+++ b/skills/epismo/references/author-playbooks.md
@@ -1,6 +1,6 @@
 # Author Playbooks
 
-Use this guide to create a Playbook or publish a new immutable Version.
+Use this guide to create a Playbook, iterate on a Draft, or publish a new immutable Version.
 
 ## Search first
 
@@ -37,11 +37,21 @@ Each hint is a `kind` + `ref` + optional `selector`, unique within a Step.
 
 Prefer a pinned or conservative selector for shared and audited work. Resolution, installation, trust, permission, and sandboxing belong to the runtime.
 
+## Iterate with a Draft
+
+A Playbook has at most one Draft: mutable, unpublished content that saves cheaply and repeatedly without minting a Version or consuming Step IDs. Use it while the Definition is still moving — it applies to an existing Playbook only, never to the first Version; a brand-new Playbook goes straight to `playbook create`.
+
+- Save with **baseRevision** set to the revision you last read, or `0` for a first Draft. A stale `baseRevision` — someone else saved since you last read it — is rejected; re-read and retry, the same discipline as a Version conflict.
+- Anyone with read access to the Playbook can read its Draft. There is no separate grant and no share-token path to it.
+- Saving does not validate or allocate Step IDs the way publishing does; that check happens once, at publish time.
+- Publishing the Draft mints a new immutable Version from its current content and discards the Draft in the same step. Discard it directly instead when the direction was wrong and should not become a Version.
+- A Draft is not a Suggestion. It is the owner's own in-progress edit, not a third party's proposal against a fixed base Version — see [Improve Playbooks](./improve-playbooks.md) for that path.
+
 ## Publish safely
 
 Creation atomically creates the Playbook and its first Version under an owner Account you manage, with an explicit non-empty ACL.
 
-Publishing requires the current **baseVersionId** and creates a new immutable Version; it never edits the base. Only an owner manager may publish, and an archived Playbook cannot receive new Versions.
+Publishing requires the current **baseVersionId** and creates a new immutable Version; it never edits the base. Publishing a Draft instead takes no `baseVersionId` — it publishes from whatever Version the Draft was last saved against, and fails the same way if latest moved underneath it in the meantime. Either way, only an owner manager may publish, and an archived Playbook cannot receive new Versions.
 
 After a conflict:
 

--- a/skills/epismo/references/improve-playbooks.md
+++ b/skills/epismo/references/improve-playbooks.md
@@ -27,7 +27,7 @@ To apply:
 3. publish a new Version through an authorized human-reviewable surface;
 4. resolve the Suggestion as applied, naming that Version as the result.
 
-Applying requires a result Version that is newer than the base Version of the same Playbook, so publish first and resolve second. Never mark applied before the corresponding Version exists.
+Applying requires a result Version that is newer than the base Version of the same Playbook, so publish first and resolve second. Never mark applied before the corresponding Version exists. Folding several open Suggestions into one Version is reasonable — stage the merged content in a Draft (see [Author Playbooks](./author-playbooks.md)) and publish it once, then resolve each Suggestion against that same result Version. A Draft is not itself a Suggestion and never substitutes for one: it holds the owner's own in-progress edit, not a reviewable third-party proposal.
 
 ## Close the loop
 

--- a/skills/epismo/references/share-playbooks.md
+++ b/skills/epismo/references/share-playbooks.md
@@ -8,6 +8,7 @@ Use this guide for ACLs, aliases, share tokens, public access, and archival.
 - **Alias:** stable human-readable reference to a logical Playbook; it grants no access.
 - **Share token:** bearer read access to one Playbook without changing its ACL.
 - **Star:** personal saving and a discovery signal, not access.
+- **Draft:** unpublished, mutable Playbook content, visible to whoever is already in the Playbook's ACL — nothing extra to grant, and a share token does not extend to it.
 
 Cases have independent ACLs and cannot be public. Tasks and Records carry no ACL of their own and are authorized through the current parent Case ACL. A cross-Case Record list checks those live Case ACLs before applying optional filters; an ACL filter only narrows results and never grants access.
 
@@ -27,7 +28,7 @@ An ACL update replaces the whole list; it is not an incremental add. Read the cu
 
 Use aliases when repeated human-readable lookup matters. Write aliases only in an owner namespace you manage. Resolve the alias, then enforce the live Playbook ACL. Before deleting or repointing an alias, distinguish changing the name, the target, and the underlying Playbook.
 
-Treat share tokens as credentials: anyone holding one can read that Playbook, and the token holder gets read access only — not the Playbook's Cases, and not the ability to start one. Only an owner manager can create a token, and the MVP surface has no revoke operation, so set an expiry when creating it rather than assuming access can be withdrawn later. Return a token only to the intended recipient and keep it out of public text, Records, and Playbook content. Archiving the Playbook is what stops existing tokens from resolving.
+Treat share tokens as credentials: anyone holding one can read that Playbook, and the token holder gets read access only — not the Playbook's Cases, and not the ability to start one. Only an owner manager can create a token, and the MVP surface has no revoke operation, so set an expiry when creating it rather than assuming access can be withdrawn later. Return a token only to the intended recipient and keep it out of public text, Records, and Playbook content. Archiving the Playbook is what stops existing tokens from resolving. A token resolves only the published Playbook, never its Draft — sharing an in-progress edit means adding the recipient to the ACL, not minting a token.
 
 ## Archive deliberately
 

--- a/skills/epismo/references/use-playbooks.md
+++ b/skills/epismo/references/use-playbooks.md
@@ -14,6 +14,8 @@ Category is a closed set used for filtering, not full-text search: `productivity
 
 References such as **pb:alias** and **pb:handle/alias** identify a logical Playbook and grant no access. A bare alias resolves against your personal namespace first, then the active workspace; the `handle/alias` form names the owner explicitly. The CLI takes UUIDs for Playbook path arguments; MCP accepts either a UUID or a reference through `epismo_playbook_get`, and exposes alias set/list/delete with the same resource/verb naming.
 
+Search, get, and version listing all surface the latest published Version — never a Draft. A Playbook mid-edit reads exactly as it did before the Draft was opened, so evaluating it here is safe even while the owner is iterating.
+
 ## Evaluate fit
 
 Check:


### PR DESCRIPTION
## Summary
- Adds the Draft concept to the Epismo skill guidance: mutable, unpublished Playbook content that saves cheaply via `baseRevision` (instead of an idempotency key) and never mints a Version until published
- Documents Draft access rules: follows the Playbook ACL, no share-token path to unpublished content
- Clarifies that publishing a Draft mints a new Version from its current content and discards the Draft in the same step
- Notes that search/get/version-listing always surface the latest published Version, never a Draft, and that share tokens never resolve a Draft

## Test plan
- [x] Reviewed rendered Markdown for `SKILL.md` and the four touched reference files
- [x] Cross-checked wording against the latest upstream MVP surface (PR #34) to avoid reintroducing stale claims