### PR TITLE
docs: refresh Epismo skill guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ macOS and Linux:
 
 ```bash
 curl -fsSL https://epismo.ai/install.sh | sh
-epismo login
-epismo whoami
 ```
 
 Windows PowerShell:
@@ -48,7 +46,19 @@ Windows PowerShell:
 irm https://epismo.ai/install.ps1 | iex
 ```
 
-Homebrew (`brew install epismoai/tap/epismo`), npm (`npm install -g epismo`), and direct downloads from [GitHub Releases](https://github.com/epismoai/cli/releases) are also supported. The npm package installs the same native executable.
+npm:
+
+```bash
+npm install -g epismo
+```
+
+The npm package installs the same native executable. Direct downloads are also available from [GitHub Releases](https://github.com/epismoai/cli/releases).
+
+After installation, see the available authentication and workspace commands:
+
+```bash
+epismo --help
+```
 
 **MCP**
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,23 @@ Use the surface available to the agent.
 
 **CLI**
 
+The CLI is a standalone native executable.
+
+macOS and Linux:
+
 ```bash
-npm install -g epismo
+curl -fsSL https://epismo.ai/install.sh | sh
 epismo login
 epismo whoami
 ```
+
+Windows PowerShell:
+
+```powershell
+irm https://epismo.ai/install.ps1 | iex
+```
+
+Homebrew (`brew install epismoai/tap/epismo`), npm (`npm install -g epismo`), and direct downloads from [GitHub Releases](https://github.com/epismoai/cli/releases) are also supported. The npm package installs the same native executable.
 
 **MCP**
 

--- a/skills/epismo/SKILL.md
+++ b/skills/epismo/SKILL.md
@@ -49,26 +49,23 @@ Do not create a Case merely to read a Playbook. Do not turn every Step into a Ta
 
 ## Surface contract
 
-- Use the Epismo surface available in the environment. Treat live MCP schemas or **epismo <command> --help** as authoritative for names, fields, enums, and limits.
-- Treat Task and Record as top-level surfaces linked by Case IDs, not as commands nested under Case. In MCP use the `epismo_task_*` and `epismo_record_*` families; in the CLI use `epismo task ...` and `epismo record ...`.
-- MCP and CLI provide the same Playbook, Case, Task, Record, Suggestion, Star, and Alias operation families. MCP tool names mirror CLI resource/verb paths in snake_case (for example, `epismo_playbook_version_list` corresponds to `epismo playbook version list`). Share tokens are CLI-only. Alias resolution is available inside `epismo_playbook_get`, not as a separate MCP tool.
-- In MCP, read the `epismo://context/current_user` resource to resolve identity before a write, `epismo://context/users` before assigning a Case or Task, and `epismo://context/projects` before constructing an ACL. In the CLI, use `epismo whoami` and the workspace/project listing commands for the same purpose.
-- CLI is the full authoring and administration surface. Successful commands emit JSON to stdout; failures emit structured errors to stderr.
-- Keep one identity and workspace throughout a connected operation. With EPISMO_TOKEN, the token's workspace overrides the saved CLI default.
-- Every mutation takes a fresh UUID idempotency key. Saving a Draft also requires `baseRevision` — the revision last read, or `0` for a first Draft. Publishing a Draft also requires `expectedDraftRevision`, the revision that was read and reviewed; in the CLI this is `--expected-draft-revision`. Reuse an idempotency key only when retrying the identical uncertain request; a reused key with different arguments is rejected. A stale Draft revision rejects either save or publish, so re-read the Draft and reconsider or retry with the current revision.
-- Identifiers are UUIDs, except Step IDs, which are four characters of `A-Z0-9`. Page sizes cap at 100.
-- Retry only transient failures. For Case and Task mutations, re-read after a lock conflict and reconsider the intent. Never replay stale intent by changing only the lock version.
+- Use the available Epismo surface. Treat its live schema or help as authoritative for operation names, fields, enums, defaults, and limits; do not infer parity with another surface.
+- Resolve identity and the active workspace before a write, then keep that context stable through the connected operation. In MCP, use the context resources before choosing an owner, assignee, or Project ACL. With `EPISMO_TOKEN`, the token's workspace overrides the CLI's saved default.
+- Prefer parent-scoped creation and browsing for child resources. Treat cross-parent Task and Suggestion lists as personal inboxes, then re-read the parent and current ACL before mutating an item selected there.
+- Reuse an idempotency key only to retry the identical request after an uncertain result. Use a fresh key after changing intent or rebasing on newer state. Draft save is revision-guarded rather than idempotency-keyed: use the last-read revision, and re-read after a conflict.
+- For Case, Task, and Draft conflicts, re-read and reconsider the change. Never replay stale intent by changing only the lock or revision number.
 
 ## Authorization
 
-An ACL is an explicit list of Account UUIDs, Project UUIDs, and — for Playbooks only — `public`. There is no implicit default: build the list deliberately, including yourself, and an empty ACL is rejected.
+An ACL contains Account UUIDs, Project UUIDs, and — for Playbooks only — `public`. Omitting a create ACL defaults to the caller's Account; an empty Playbook create ACL does the same, while an empty Case ACL is rejected. ACL updates always reject an empty list and replace the complete ACL, so read the current state and build the replacement deliberately.
 
 Access separates read from write:
 
-- Playbook reads follow the Playbook ACL or a valid share token. Publishing, ACL changes, archival, aliases, and share tokens require rights over the owner Account.
-- Draft reads follow the Playbook ACL, not a share token — there is no token-based path to unpublished content. Saving, discarding, and publishing a Draft require rights over the owner Account, the same as publishing a Version directly.
+- Playbook reads follow the current Playbook ACL. Publishing, ACL changes, archival, and Version archival require rights over the Playbook's owner Account. Any authenticated reader may manage an alias only in a personal or managed Workspace namespace they control.
+- Draft reads and writes require rights over the Playbook's owner Account. A Playbook reader or share-link holder cannot read unpublished content.
 - Case, Task, and Record reads follow the current Case ACL. Task and Record have no ACL of their own.
-- Case writes require being the Case starter or its current assignee. ACL membership alone is read access, so plan ownership before delegating.
+- Any caller covered by the current Case ACL may append Records while the Case is open. Case-level mutations and Task creation require being the Case starter or its current assignee; existing Tasks have narrower, Task-specific write rules.
+- Share links need separate care: a readable Playbook currently yields one stable token with no expiry or revoke operation, and the web route does not bypass the Playbook ACL. Read [Share Playbooks](./references/share-playbooks.md) before creating or relying on one.
 
 The user's direct request authorizes ordinary private creates and updates within its scope. Require explicit intent before:
 

--- a/skills/epismo/references/author-playbooks.md
+++ b/skills/epismo/references/author-playbooks.md
@@ -8,20 +8,11 @@ Search existing Playbooks before creating one. Improve a fitting Playbook when t
 
 ## Write the Definition
 
-A Definition holds exactly these fields, and unknown fields are rejected:
-
-- **schemaVersion** — only `1` is supported.
-- **title** — required; name the outcome.
-- **description** — say concisely when to use it.
-- **category** — optional, and one of `productivity`, `programming`, `design`, `sales`, `marketing`, `operations`, `learning`.
-- **inputSchema** — JSON Schema Draft 2020-12 whose root type is an object; omit it to accept any object.
-- **steps** — ordered guidance, each with a title, instructions, optional resource hints, and optional expected outputs.
-
 Write Steps as judgment-sized guidance rather than tiny commands or a rigid execution graph. Array order is the recommended order; there is no position field, status, or assignee on a Step. Expected outputs are free-form JSON hints, not completion criteria. Keep run-specific facts in Cases and large background material in referenced documents.
 
 ## Keep Step identity stable
 
-The server owns Step IDs: four characters of `A-Z0-9`, unique across every Version of the same Playbook.
+The server owns Step IDs and never reuses one within the same Playbook.
 
 - Omit the ID for a new Step, including when publishing from a base Version. The server assigns one and returns the published Definition.
 - Send the existing ID when editing or reordering a Step that already exists in the base Version — that is what preserves its identity across Versions.
@@ -29,30 +20,24 @@ The server owns Step IDs: four characters of `A-Z0-9`, unique across every Versi
 
 ## Reference resources as hints
 
-Each hint is a `kind` + `ref` + optional `selector`, unique within a Step.
-
-- **kind** is one of `skill`, `mcp`, `cli`, `api`, `plugin`, `graph`, `document`, `agent`, `custom`.
-- **ref** must use an allowed scheme (`clawhub`, `mcp`, `github`, `https`, `http`, `file`, `skill`, `plugin`, `document`) and must not contain credentials, userinfo, secret query parameters, or expiring signed URLs.
-- **selector** is an opaque string such as `stable`, `main`, or `^1`. Epismo stores it without resolving or validating it.
-
-Prefer a pinned or conservative selector for shared and audited work. Resolution, installation, trust, permission, and sandboxing belong to the runtime.
+Treat each resource hint as a discovery hint, not an installation or trust decision. Never put credentials or expiring signed URLs in one. Prefer a pinned or conservative selector for shared and audited work; resolution, permission, and sandboxing belong to the runtime.
 
 ## Iterate with a Draft
 
-A Playbook has at most one Draft: mutable, unpublished content that saves cheaply and repeatedly without minting a Version or consuming Step IDs. Use it while the Definition is still moving — it applies to an existing Playbook only, never to the first Version; a brand-new Playbook goes straight to `playbook create`.
+A Playbook has at most one Draft: mutable, unpublished content that saves cheaply and repeatedly without minting a Version or consuming Step IDs. Use it while the Definition is still moving. A Draft applies only to an existing Playbook; create the first Version directly.
 
-- Save with **baseRevision** set to the revision you last read, or `0` for a first Draft. A stale `baseRevision` — someone else saved since you last read it — is rejected; re-read and retry, the same discipline as a Version conflict.
-- Before publishing, read and review the Draft, then pass that returned revision as **expectedDraftRevision** (CLI: `--expected-draft-revision`). The publish is rejected if anyone saved a newer Draft after that read; re-read, review the current content, and publish only when it is still the intended change.
-- Anyone with read access to the Playbook can read its Draft. There is no separate grant and no share-token path to it.
-- Saving does not validate or allocate Step IDs the way publishing does; that check happens once, at publish time.
+- Save against the revision you last read, or the new-Draft sentinel when none exists. If someone else saved first, re-read and merge deliberately.
+- Before publishing, read and review the Draft, then publish against that returned revision. If anyone saves after the review, re-read the newer content before deciding again.
+- Only an owner manager can read, save, discard, or publish a Draft. There is no reader-ACL or share-link path to unpublished content.
+- Saving validates the Definition and any retained Step IDs, but does not allocate IDs for new Steps. Allocation happens when publishing.
 - Publishing the Draft mints a new immutable Version from its current content and discards the Draft in the same step. Discard it directly instead when the direction was wrong and should not become a Version.
 - A Draft is not a Suggestion. It is the owner's own in-progress edit, not a third party's proposal against a fixed base Version — see [Improve Playbooks](./improve-playbooks.md) for that path.
 
 ## Publish safely
 
-Creation atomically creates the Playbook and its first Version under an owner Account you manage, with an explicit non-empty ACL.
+Creation atomically creates the Playbook and its first Version under an owner Account you manage. If no ACL is supplied, the shared operation makes it private to the caller's Account.
 
-Publishing requires the current **baseVersionId** and creates a new immutable Version; it never edits the base. Publishing a Draft instead takes no `baseVersionId`, but does require the reviewed **expectedDraftRevision** — it publishes from whatever Version the Draft was last saved against, and fails if either that Draft revision or the latest Version moved underneath it in the meantime. Either way, only an owner manager may publish, and an archived Playbook cannot receive new Versions.
+Direct publishing must be based on the current latest Version and creates a new immutable Version; it never edits the base. Draft publishing uses the reviewed Draft revision and the Version captured by its last save. It fails if either moved in the meantime. Either way, only an owner manager may publish, and an archived Playbook cannot receive new Versions.
 
 After a conflict:
 

--- a/skills/epismo/references/coordinate-cases.md
+++ b/skills/epismo/references/coordinate-cases.md
@@ -6,19 +6,19 @@ Use this guide when real work needs shared state, ownership, review, or a durabl
 
 Start from an immutable Playbook Version when following reusable guidance; the Case fixes that Version ID and digest for its lifetime. Start an ad hoc Case with a title when no suitable Playbook exists.
 
-Input is validated against the pinned Version's schema before the Case exists. An ad hoc Case validates nothing.
+Input is validated against the pinned Version's schema before the Case exists. An ad hoc Case has no Playbook input-schema validation.
 
-A Case ACL is explicit, non-empty, must include you, and cannot contain `public`. A Case never inherits public or share-token access from its Playbook.
+A Case ACL cannot contain `public` and never inherits access from its Playbook. If omitted at creation, it defaults to the caller's Account. When supplied or replaced, it must continue to cover the current assignee, including through a Project.
 
 Do not create a Case when reading and local execution are enough.
 
 ## Know who may write
 
-Every Case mutation — creating a Task, appending a Record, assigning, retitling, replacing the ACL, closing, reopening — is limited to the Case starter and the current Case assignee. Everyone else in the ACL can read only. Assigning the Case is therefore how write responsibility moves, so decide ownership before delegating.
+Everyone covered by the current Case ACL may read the Case and append Records while it is open. Creating Tasks, assigning, retitling, replacing the ACL, closing, and reopening remain limited to the Case starter and current Case assignee. Reassignment changes day-to-day responsibility, but the starter retains management authority.
 
 Task rights are narrower than the Case:
 
-- Assign a Task: its creator, the Case starter, or the Case assignee.
+- Assign or edit a Task: its creator, the Case starter, or the Case assignee.
 - Close or reopen a **work** Task: its assignee or its creator.
 - Close or reopen a **review** Task: its assignee only.
 
@@ -27,7 +27,7 @@ Task rights are narrower than the Case:
 - Keep local intermediate work in the agent runtime.
 - Use the Case assignee for overall responsibility.
 - Create a **work** Task for a concrete delegated result.
-- Create a **review** Task when a person or agent must judge a specific Record. A review Task always needs an assignee, and only a review Task may name a subject Record.
+- Create a **review** Task when a person or agent must judge a specific Record. A review Task always needs an assignee, and only a review Task may name a subject Record. Verify that subject belongs to the same Case; the current service does not enforce that relationship.
 - Link a Task to a source Step only when that provenance helps. The Step ID must exist in the Case's pinned Version; ad hoc Tasks are valid.
 - Allow multiple open Tasks when work is genuinely parallel.
 
@@ -49,14 +49,13 @@ Constraints worth designing around:
 
 - Records can be appended only while the Case is open. Closing a Case or Task accepts its final Records in the same call — use that instead of racing a separate append.
 - Origin is `user` or `agent`. The server owns `system` origin and the `activity` kind, which it writes for lifecycle events.
-- A kind is 1–64 characters of your own vocabulary; content is text up to 1 MB; structured payloads go in data.
 - Credentials in data are rejected, including URLs carrying tokens or userinfo.
 
 Do not store chain-of-thought, credentials, every tool call, raw shell output, heartbeat, or transient retries.
 
 ## Browse the activity feed
 
-List Records without a Case filter to browse activity across every Case the caller can currently read. Narrow the feed only when useful:
+List Records across every Case the caller can currently read. Narrow the feed only when useful:
 
 - filter by Case, Task, creator, kind, or origin;
 - filter by ACL principal to select accessible Cases whose current ACL contains that principal;
@@ -64,7 +63,7 @@ List Records without a Case filter to browse activity across every Case the call
 
 Never treat an ACL filter as authorization. The service first applies the caller's live principals to each Case ACL, then applies requested filters; filters can only reduce the result set.
 
-Listing Tasks works the same way within a Case. Across Cases, the Task list is an assignee inbox and requires an assignee filter.
+Browse Tasks within a Case when coordinating that work. Use the cross-Case Task view as an assignee inbox, not as a substitute for reading the parent before a mutation.
 
 ## Close safely
 
@@ -74,7 +73,7 @@ Close a Task with an explicit outcome. Reopen only when the user intends work to
 
 Closing a Case is consequential:
 
-- `completed` requires zero open Tasks — close or reassign them first;
+- `completed` requires zero open Tasks — close every open Task first;
 - `cancelled` and `abandoned` close every remaining open Task as cancelled;
 - reopening a Case leaves its Tasks closed, so reopen the ones that should resume.
 

--- a/skills/epismo/references/coordinate-cases.md
+++ b/skills/epismo/references/coordinate-cases.md
@@ -53,15 +53,9 @@ Constraints worth designing around:
 
 Do not store chain-of-thought, credentials, every tool call, raw shell output, heartbeat, or transient retries.
 
-## Browse the activity feed
+## Browse a Case timeline
 
-List Records across every Case the caller can currently read. Narrow the feed only when useful:
-
-- filter by Case, Task, creator, kind, or origin;
-- filter by ACL principal to select accessible Cases whose current ACL contains that principal;
-- choose ascending or descending order and follow the returned cursor for stable pagination.
-
-Never treat an ACL filter as authorization. The service first applies the caller's live principals to each Case ACL, then applies requested filters; filters can only reduce the result set.
+List Records within their parent Case. Filters can only narrow that authorized timeline and never grant access. The public CLI and MCP surfaces do not expose the internal cross-Case Record query.
 
 Browse Tasks within a Case when coordinating that work. Use the cross-Case Task view as an assignee inbox, not as a substitute for reading the parent before a mutation.
 

--- a/skills/epismo/references/share-playbooks.md
+++ b/skills/epismo/references/share-playbooks.md
@@ -5,12 +5,12 @@ Use this guide for ACLs, aliases, share tokens, public access, and archival.
 ## Choose the mechanism
 
 - **ACL:** durable access for User Account IDs and Project IDs; Playbooks may also include `public`.
-- **Alias:** stable human-readable reference to a logical Playbook; it grants no access.
-- **Share token:** bearer read access to one Playbook without changing its ACL.
+- **Alias:** one Account namespace's human-readable reference to a Playbook; it grants no access.
+- **Share URL:** an opaque token URL intended for recipient access; the current web flow still applies the Playbook ACL.
 - **Star:** personal saving and a discovery signal, not access.
-- **Draft:** unpublished, mutable Playbook content, visible to whoever is already in the Playbook's ACL — nothing extra to grant, and a share token does not extend to it.
+- **Draft:** unpublished, mutable Playbook content restricted to owner managers; neither the reader ACL nor a share link grants access.
 
-Cases have independent ACLs and cannot be public. Tasks and Records carry no ACL of their own and are authorized through the current parent Case ACL. A cross-Case Record list checks those live Case ACLs before applying optional filters; an ACL filter only narrows results and never grants access.
+Cases have independent ACLs and cannot be public. Tasks and Records carry no ACL of their own and are authorized through the current parent Case ACL. Anyone covered by that live ACL may append Records to an open Case; managing the Case and creating Tasks remain limited to its starter and assignee. Records can be listed across readable Cases, and optional filters only narrow results; they never grant access.
 
 ## Expand access carefully
 
@@ -26,9 +26,11 @@ An ACL update replaces the whole list; it is not an incremental add. Read the cu
 
 ## Manage references
 
-Use aliases when repeated human-readable lookup matters. Write aliases only in an owner namespace you manage. Resolve the alias, then enforce the live Playbook ACL. Before deleting or repointing an alias, distinguish changing the name, the target, and the underlying Playbook.
+Use an alias when repeated human-readable lookup matters. Each personal or managed Workspace namespace can assign at most one alias to any readable Playbook. Setting a different alias for the same Playbook renames that namespace's reference; it does not move an alias already occupied by another Playbook. The Playbook owner's alias is official and may be indexed. A third-party alias is not indexed or shown as official; do not surface it outside its namespace even though a raw alias listing may return it. Resolution enforces the live Playbook ACL, so an alias never preserves access after removal.
 
-Treat share tokens as credentials: anyone holding one can read that Playbook, and the token holder gets read access only — not the Playbook's Cases, and not the ability to start one. Only an owner manager can create a token, and the MVP surface has no revoke operation, so set an expiry when creating it rather than assuming access can be withdrawn later. Create one with `epismo playbook share <playbook-id>`; it returns the share URL. Return that URL only to the intended recipient and keep it out of public text, Records, and Playbook content. Archiving the Playbook is what stops existing tokens from resolving. A token resolves only the published Playbook, never its Draft — sharing an in-progress edit means adding the recipient to the ACL, not minting a token.
+Treat a share URL as a credential even though the current web flow does not grant ACL-bypassing access. Any authenticated reader can create or retrieve the Playbook's single stable token; there is currently no expiry, rotation, or revoke operation. Do not create one speculatively, and keep it out of public text, Playbook content, Cases, Records, and logs.
+
+Before relying on a share URL, verify it as the intended recipient in the intended workspace or anonymous context. Today the web route resolves the token to a Playbook ID and then performs the normal Playbook read, so a private Playbook still requires ACL access. Archiving blocks the resulting Playbook read but does not delete the token mapping. A share URL never grants access to a Draft, Case, Task, or Record.
 
 ## Archive deliberately
 

--- a/skills/epismo/references/use-playbooks.md
+++ b/skills/epismo/references/use-playbooks.md
@@ -4,17 +4,14 @@ Use this guide to discover, evaluate, and apply existing guidance.
 
 ## Discover narrowly
 
-1. Search readable Playbooks by intent. A free-text query, an optional category, and paging are the primary controls; a Lucene filter expression and field aggregations are available when a catalog view needs faceting.
-2. Compare compact results before fetching full Definitions. Each result carries the latest Version, its digest, and star counts.
-3. Get a specific Version for promising candidates.
-4. Pin the Version ID when reproducibility matters. A Case fixes the Version and digest it started with, so later publishes never change the instructions a Case was run under.
-5. Star a Playbook only when the user wants to save it or actual use shows value. Both surfaces support it: `epismo playbook star`/`unstar` in the CLI, `epismo_playbook_star`/`epismo_playbook_unstar` in MCP.
+1. Search readable Playbooks by intent and compare compact results before opening full guidance.
+2. Fetch the specific Version for promising candidates; search projections are not the full Definition.
+3. Pin the Version ID when reproducibility matters. A Case fixes the Version and digest it started with, so later publishes never change the instructions a Case was run under.
+4. Star a Playbook only when the user wants to save it or actual use shows value.
 
-Category is a closed set used for filtering, not full-text search: `productivity`, `programming`, `design`, `sales`, `marketing`, `operations`, `learning`.
+References such as **pb:alias** and **pb:handle/alias** identify a logical Playbook and grant no access. A bare alias resolves against the caller's personal namespace first, then the active workspace; the qualified form names a namespace explicitly. The Playbook owner's alias is portable and may be indexed. A third-party alias is not indexed or official; treat it as namespace-local even though a raw alias listing may expose it to other readers of the Playbook.
 
-References such as **pb:alias** and **pb:handle/alias** identify a logical Playbook and grant no access. A bare alias resolves against your personal namespace first, then the active workspace; the `handle/alias` form names the owner explicitly. The CLI takes UUIDs for Playbook path arguments; MCP accepts either a UUID or a reference through `epismo_playbook_get`, and exposes alias set/list/delete with the same resource/verb naming.
-
-Search, get, and version listing all surface the latest published Version — never a Draft. A Playbook mid-edit reads exactly as it did before the Draft was opened, so evaluating it here is safe even while the owner is iterating.
+Catalog search and Playbook reads expose the latest published Version, while Version history exposes prior immutable publications. None of these surfaces returns a Draft, so a Playbook mid-edit still reads as its last publication.
 
 ## Evaluate fit
 


### PR DESCRIPTION
## Summary
- document the native Epismo CLI installation paths
- align Playbook, Draft, ACL, alias, sharing, Case, Task, and Record guidance with the current surface
- retain cross-Case Record browsing guidance, including authorization-safe filtering

## Validation
- `git diff --check`
- reviewed installed `epismo` CLI help (v1.3.0)