### PR TITLE
docs: update Playbook access guidance

### DIFF
--- a/skills/epismo/SKILL.md
+++ b/skills/epismo/SKILL.md
@@ -57,15 +57,15 @@ Do not create a Case merely to read a Playbook. Do not turn every Step into a Ta
 
 ## Authorization
 
-An ACL contains Account UUIDs, Team UUIDs, and — for Playbooks only — `public`. Omitting a create ACL defaults to the caller's Account; an empty Playbook create ACL does the same, while an empty Case ACL is rejected. ACL updates always reject an empty list and replace the complete ACL, so read the current state and build the replacement deliberately.
+Playbook access uses `visibility` (`private` or `public`) plus explicit `editors` (active User Account or Team UUIDs). `public` grants published read access only; editors can read and edit content. Owners are implicit, never appear in editors, and Workspace Owners/Admins manage Workspace-owned Playbooks. A private owner-only Playbook and a public Playbook with no editors both use an empty editor list. Case ACLs remain separate and reject an empty list.
 
 Access separates read from write:
 
-- Playbook reads follow the current Playbook ACL. Publishing, ACL changes, archival, and Version archival require rights over the Playbook's owner Account. Any authenticated reader may manage an alias only in a personal or managed Workspace namespace they control.
-- Draft reads and writes require rights over the Playbook's owner Account. A Playbook reader or share-link holder cannot read unpublished content.
+- Playbook reads follow current visibility and access. Public readers can only read published content; editors can publish and edit content. Access management, Playbook archival, and historical Version archival require an owner manager. Any authenticated reader may manage an alias only in a personal or managed Workspace namespace they control.
+- Draft reads and writes require Playbook edit access. A public reader or share-link holder cannot read unpublished content.
 - Case, Task, and Record reads follow the current Case ACL. Task and Record have no ACL of their own.
 - Any caller covered by the current Case ACL may append Records while the Case is open. Case-level mutations and Task creation require being the Case starter or its current assignee; existing Tasks have narrower, Task-specific write rules.
-- Share links need separate care: a readable Playbook currently yields one stable token with no expiry or revoke operation, and the web route does not bypass the Playbook ACL. Read [Share Playbooks](./references/share-playbooks.md) before creating or relying on one.
+- Share links need separate care: a readable Playbook currently yields one stable token with no expiry or revoke operation, and the web route does not bypass Playbook access. Read [Share Playbooks](./references/share-playbooks.md) before creating or relying on one.
 
 The user's direct request authorizes ordinary private creates and updates within its scope. Require explicit intent before:
 

--- a/skills/epismo/references/author-playbooks.md
+++ b/skills/epismo/references/author-playbooks.md
@@ -46,4 +46,4 @@ After a conflict:
 3. merge deliberately;
 4. publish with a new idempotency key.
 
-Verify the new Version ID, Definition, Step IDs, ACL, canonical digest, and latest pointer. Publishing is a reviewable change to shared guidance: show the diff before publishing on someone's behalf. Creating or publishing in an owner namespace you do not manage requires an authorized surface and role; otherwise create a Suggestion.
+Verify the new Version ID, Definition, Step IDs, access, canonical digest, and latest pointer. Publishing is a reviewable change to shared guidance: show the diff before publishing on someone's behalf. Creating or publishing in an owner namespace you do not manage requires an authorized surface and role; otherwise create a Suggestion.

--- a/skills/epismo/references/author-playbooks.md
+++ b/skills/epismo/references/author-playbooks.md
@@ -28,16 +28,16 @@ A Playbook has at most one Draft: mutable, unpublished content that saves cheapl
 
 - Save against the revision you last read, or the new-Draft sentinel when none exists. If someone else saved first, re-read and merge deliberately.
 - Before publishing, read and review the Draft, then publish against that returned revision. If anyone saves after the review, re-read the newer content before deciding again.
-- Only an owner manager can read, save, discard, or publish a Draft. There is no reader-ACL or share-link path to unpublished content.
+- Editors and owner managers can read, save, discard, or publish a Draft. Public readers and share links have no path to unpublished content.
 - Saving validates the Definition and any retained Step IDs, but does not allocate IDs for new Steps. Allocation happens when publishing.
 - Publishing the Draft mints a new immutable Version from its current content and discards the Draft in the same step. Discard it directly instead when the direction was wrong and should not become a Version.
 - A Draft is not a Suggestion. It is the owner's own in-progress edit, not a third party's proposal against a fixed base Version — see [Improve Playbooks](./improve-playbooks.md) for that path.
 
 ## Publish safely
 
-Creation atomically creates the Playbook and its first Version under an owner Account you manage. If no ACL is supplied, the shared operation makes it private to the caller's Account.
+Creation atomically creates the Playbook and its first Version under an owner Account you manage. Use `visibility` and `editors` for access; omitting editors creates a private owner-only Playbook.
 
-Direct publishing must be based on the current latest Version and creates a new immutable Version; it never edits the base. Draft publishing uses the reviewed Draft revision and the Version captured by its last save. It fails if either moved in the meantime. Either way, only an owner manager may publish, and an archived Playbook cannot receive new Versions.
+Direct publishing must be based on the current latest Version and creates a new immutable Version; it never edits the base. Draft publishing uses the reviewed Draft revision and the Version captured by its last save. It fails if either moved in the meantime. Editors and owner managers may publish; an archived Playbook cannot receive new Versions.
 
 After a conflict:
 

--- a/skills/epismo/references/improve-playbooks.md
+++ b/skills/epismo/references/improve-playbooks.md
@@ -10,7 +10,7 @@ Use this guide when real use reveals a repeatable improvement.
 
 Create the Suggestion against the Playbook and the immutable base Version that produced the observation; the base must be a Version of that same Playbook. Include the problem, proposed change, and expected benefit, and name a target Step only when that Step ID exists in the base Version.
 
-A Suggestion snapshots the Playbook ACL when it is created. Reading it later requires access under both that snapshot and the Playbook's current ACL, so access removed from the Playbook also closes the Suggestion.
+A Suggestion snapshots Playbook access when it is created. Reading it later requires access under both that snapshot and the Playbook's current access, so access removed from the Playbook also closes the Suggestion.
 
 ## Work with ownership
 

--- a/skills/epismo/references/share-playbooks.md
+++ b/skills/epismo/references/share-playbooks.md
@@ -4,9 +4,9 @@ Use this guide for ACLs, aliases, share tokens, public access, and archival.
 
 ## Choose the mechanism
 
-- **ACL:** durable access for User Account IDs and Team IDs; Playbooks may also include `public`.
+- **Playbook access:** `visibility` plus durable editor User Account and Team IDs. `public` permits published reads only; owners are implicit.
 - **Alias:** one Account namespace's human-readable reference to a Playbook; it grants no access.
-- **Share URL:** an opaque token URL intended for recipient access; the current web flow still applies the Playbook ACL.
+- **Share URL:** an opaque token URL intended for recipient access; the current web flow still applies Playbook access.
 - **Star:** personal saving and a discovery signal, not access.
 - **Draft:** unpublished, mutable Playbook content restricted to owner managers; neither the reader ACL nor a share link grants access.
 
@@ -22,18 +22,18 @@ Require explicit intent before public access or a wider audience. Before expandi
 - confirm owner, workspace, and team principals;
 - preserve unrelated ACL entries only when the operation and user's intent allow it.
 
-An ACL update replaces the whole list; it is not an incremental add. Read the current access before replacing it. A Playbook ACL change requires rights over the owner Account. A Case ACL change requires the Case starter or assignee, the current lock version, and an ACL that still covers every current Case and Task assignee — the service rejects an update that would strand one rather than silently unassigning them.
+`playbook access set` replaces the complete editor list; it is not an incremental add. Read current access before replacing it, and retain editor IDs that the caller cannot resolve. Only an owner manager can change Playbook access. A Case ACL change requires the Case starter or assignee, the current lock version, and an ACL that still covers every current Case and Task assignee — the service rejects an update that would strand one rather than silently unassigning them.
 
 ## Manage references
 
-Use an alias when repeated human-readable lookup matters. Each personal or managed Workspace namespace can assign at most one alias to any readable Playbook. Setting a different alias for the same Playbook renames that namespace's reference; it does not move an alias already occupied by another Playbook. The Playbook owner's alias is official and may be indexed. A third-party alias is not indexed or shown as official; do not surface it outside its namespace even though a raw alias listing may return it. Resolution enforces the live Playbook ACL, so an alias never preserves access after removal.
+Use an alias when repeated human-readable lookup matters. Each personal or managed Workspace namespace can assign at most one alias to any readable Playbook. Setting a different alias for the same Playbook renames that namespace's reference; it does not move an alias already occupied by another Playbook. The Playbook owner's alias is official and may be indexed. A third-party alias is not indexed or shown as official; do not surface it outside its namespace even though a raw alias listing may return it. Resolution enforces live Playbook access, so an alias never preserves access after removal.
 
-Treat a share URL as a credential even though the current web flow does not grant ACL-bypassing access. Any authenticated reader can create or retrieve the Playbook's single stable token; there is currently no expiry, rotation, or revoke operation. Do not create one speculatively, and keep it out of public text, Playbook content, Cases, Records, and logs.
+Treat a share URL as a credential even though the current web flow does not bypass Playbook access. Any authenticated reader can create or retrieve the Playbook's single stable token; there is currently no expiry, rotation, or revoke operation. Do not create one speculatively, and keep it out of public text, Playbook content, Cases, Records, and logs.
 
-Before relying on a share URL, verify it as the intended recipient in the intended workspace or anonymous context. Today the web route resolves the token to a Playbook ID and then performs the normal Playbook read, so a private Playbook still requires ACL access. Archiving blocks the resulting Playbook read but does not delete the token mapping. A share URL never grants access to a Draft, Case, Task, or Record.
+Before relying on a share URL, verify it as the intended recipient in the intended workspace or anonymous context. Today the web route resolves the token to a Playbook ID and then performs the normal Playbook read, so a private Playbook still requires access. Archiving blocks the resulting Playbook read but does not delete the token mapping. A share URL never grants access to a Draft, Case, Task, or Record.
 
 ## Archive deliberately
 
 Archive a Playbook only with explicit intent. It disappears from search, direct reads, and starred lists, and it accepts no further Versions, Cases, or share tokens.
 
-Archival reaches further than discovery: its Versions stop resolving too. Existing Cases keep their pinned Version ID and digest and stay readable as Cases, but the Definition behind them can no longer be fetched. Prefer narrowing the ACL when guidance should merely stop spreading, and archive when the Playbook itself should end.
+Archival reaches further than discovery: its Versions stop resolving too. Existing Cases keep their pinned Version ID and digest and stay readable as Cases, but the Definition behind them can no longer be fetched. Prefer narrowing access when guidance should merely stop spreading, and archive when the Playbook itself should end.

--- a/skills/epismo/references/share-playbooks.md
+++ b/skills/epismo/references/share-playbooks.md
@@ -8,7 +8,7 @@ Use this guide for ACLs, aliases, share tokens, public access, and archival.
 - **Alias:** one Account namespace's human-readable reference to a Playbook; it grants no access.
 - **Share URL:** an opaque token URL intended for recipient access; the current web flow still applies Playbook access.
 - **Star:** personal saving and a discovery signal, not access.
-- **Draft:** unpublished, mutable Playbook content restricted to owner managers; neither the reader ACL nor a share link grants access.
+- **Draft:** unpublished, mutable Playbook content restricted to editors and owner managers; neither public readers nor a share link grants access.
 
 Cases have independent ACLs and cannot be public. Tasks and Records carry no ACL of their own and are authorized through the current parent Case ACL. Anyone covered by that live ACL may append Records to an open Case; managing the Case and creating Tasks remain limited to its starter and assignee. Records can be listed across readable Cases, and optional filters only narrow results; they never grant access.
 


### PR DESCRIPTION
## Summary
- teach agents to use visibility and editors for Playbook access
- clarify editor content and Draft permissions plus owner-manager governance
- retain separate Case ACL guidance

## Verification
- documentation-only change