### PR TITLE
Correct Task status rights and drop the Case digest

### DIFF
--- a/skills/epismo/references/coordinate-cases.md
+++ b/skills/epismo/references/coordinate-cases.md
@@ -4,7 +4,7 @@ Use this guide when real work needs shared state, ownership, review, or a durabl
 
 ## Start deliberately
 
-Start from an immutable Playbook Version when following reusable guidance; the Case fixes that Version ID and digest for its lifetime. Start an ad hoc Case with a title when no suitable Playbook exists.
+Start from an immutable Playbook Version when following reusable guidance; the Case fixes that Version ID for its lifetime. Start an ad hoc Case with a title when no suitable Playbook exists.
 
 Input is validated against the pinned Version's schema before the Case exists. An ad hoc Case has no Playbook input-schema validation.
 
@@ -19,15 +19,15 @@ Everyone covered by the current Case ACL may read the Case and append Records wh
 Task rights are narrower than the Case:
 
 - Assign or edit a Task: its creator, the Case starter, or the Case assignee.
-- Close or reopen a **work** Task: its assignee or its creator.
-- Close or reopen a **review** Task: its assignee only.
+- Close or reopen a **work** Task: anyone the Case ACL covers. Work status is shared state, not the assignee's private business.
+- Close or reopen a **review** Task: its assignee, or anyone the Case ACL covers while it has none. A review records an approval, so a named reviewer is the only one who can give it.
 
 ## Materialize only shared work
 
 - Keep local intermediate work in the agent runtime.
 - Use the Case assignee for overall responsibility.
 - Create a **work** Task for a concrete delegated result.
-- Create a **review** Task when a person or agent must judge a specific Record. A review Task always needs an assignee, and only a review Task may name a subject Record. Verify that subject belongs to the same Case; the current service does not enforce that relationship.
+- Create a **review** Task when a person or agent must judge a specific Record. Always name the reviewer, otherwise anyone the Case ACL covers can resolve it. Only a review Task may name a subject Record. Verify that subject belongs to the same Case; the current service does not enforce that relationship.
 - Link a Task to a source Step only when that provenance helps. The Step ID must exist in the Case's pinned Version; ad hoc Tasks are valid.
 - Allow multiple open Tasks when work is genuinely parallel.
 

--- a/skills/epismo/references/share-playbooks.md
+++ b/skills/epismo/references/share-playbooks.md
@@ -36,4 +36,4 @@ Before relying on a share URL, verify it as the intended recipient in the intend
 
 Archive a Playbook only with explicit intent. It disappears from search, direct reads, and starred lists, and it accepts no further Versions, Cases, or share tokens.
 
-Archival reaches further than discovery: its Versions stop resolving too. Existing Cases keep their pinned Version ID and digest and stay readable as Cases, but the Definition behind them can no longer be fetched. Prefer narrowing access when guidance should merely stop spreading, and archive when the Playbook itself should end.
+Archival reaches further than discovery: its Versions stop resolving too. Existing Cases keep their pinned Version ID and stay readable as Cases, but the Definition behind them can no longer be fetched. Prefer narrowing access when guidance should merely stop spreading, and archive when the Playbook itself should end.


### PR DESCRIPTION
## Why

Two statements in the Case guide no longer match how the service behaves.

**Task status rights.** Closing or reopening a work Task was limited to its
assignee and its creator. It is now open to anyone the Case ACL covers: a Case is
worked on together, and a work Task's status is shared state rather than the
assignee's private business. A review Task keeps the narrower rule, because it
records an approval that the named reviewer has to give.

The guide also told authors that a review Task always needs an assignee. The
service does not require one, and an unassigned review can be resolved by anyone
the Case ACL covers, so naming the reviewer is advice worth giving with its
reason attached rather than a constraint the reader can rely on.

**Case digest.** A Case no longer stores the digest of the Playbook Version it
pins. The Version ID is what identifies the guidance a Case follows, and the
digest was never read back, so both guides now say only that.

## Scope

Wording only, in `references/coordinate-cases.md` and
`references/share-playbooks.md`. No operation names, fields, or enums change.
