### PR TITLE
Document public Cases, implicit assignee access, and Case share links

### DIFF
--- a/skills/epismo/SKILL.md
+++ b/skills/epismo/SKILL.md
@@ -24,7 +24,7 @@ Route by intent:
 | Create or publish reusable guidance                      | [Author Playbooks](./references/author-playbooks.md)   |
 | Start work, assign it, record outcomes, review, or close | [Coordinate Cases](./references/coordinate-cases.md)   |
 | Feed learning back into a Playbook                       | [Improve Playbooks](./references/improve-playbooks.md) |
-| Change ACLs, aliases, share tokens, or public visibility | [Share Playbooks](./references/share-playbooks.md)     |
+| Change ACLs, aliases, share tokens, or public visibility | [Share access](./references/share-playbooks.md)        |
 
 Read only the relevant guide. Read more than one only when the request crosses stages.
 
@@ -57,14 +57,14 @@ Do not create a Case merely to read a Playbook. Do not turn every Step into a Ta
 
 ## Authorization
 
-Playbook access uses `visibility` (`private` or `public`) plus explicit `editors` (active User Account or Team UUIDs). `public` grants published read access only; editors can read and edit content. Owners are implicit, never appear in editors, and Workspace Owners/Admins manage Workspace-owned Playbooks. A private owner-only Playbook and a public Playbook with no editors both use an empty editor list. Case ACLs remain separate and reject an empty list.
+Playbooks use `visibility` (`private` or `public`) plus explicit `editors` (active User Account or Team UUIDs). `public` grants published read access only; editors can read and edit content. Owners are implicit, never appear in editors, and Workspace Owners/Admins manage Workspace-owned Playbooks. A private owner-only Playbook and a public Playbook with no editors both use an empty editor list. Cases use their own ACL: `public` immediately grants read-only access to the current title, Records, and readable handoffs, including later Records. Non-public ACL principals can continue the work; the current Case assignee has implicit work and management access and is omitted from the editor list.
 
 Access separates read from write:
 
 - Playbook reads follow current visibility and access. Public readers can only read published content; editors can publish and edit content. Access management, Playbook archival, and historical Version archival require an owner manager. Any authenticated reader may manage an alias only in a personal or managed Workspace namespace they control.
 - Draft reads and writes require Playbook edit access. A public reader or share-link holder cannot read unpublished content.
-- Case, Task, and Record reads follow the current Case ACL. Task and Record have no ACL of their own.
-- Any caller covered by the current Case ACL may append Records while the Case is open. Case-level mutations and Task creation require being the Case starter or its current assignee; existing Tasks have narrower, Task-specific write rules.
+- Case, Task, and Record reads follow the current Case ACL. A public-only reader receives the current title, Records, and readable handoffs, without Tasks, assignment, input, or collaborator identities. Task and Record have no ACL of their own.
+- Any caller covered by the current Case ACL may append Records while the Case is open. Case-level management (assignment, ACL or access, retitle, close, reopen) requires being the current Case assignee; `started_by` is history. ACL editors can create Tasks. Existing Tasks have narrower, Task-specific write rules.
 - Share links need separate care: a readable Playbook currently yields one stable token with no expiry or revoke operation, and the web route does not bypass Playbook access. Read [Share Playbooks](./references/share-playbooks.md) before creating or relying on one.
 
 The user's direct request authorizes ordinary private creates and updates within its scope. Require explicit intent before:

--- a/skills/epismo/SKILL.md
+++ b/skills/epismo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: epismo
-description: Use Epismo to find, inspect, star, author, version, share, and improve reusable Playbooks; start and coordinate Cases, Tasks, Records, assignments, reviews, and handoffs; and manage durable work context through the available Epismo MCP or CLI surface. Trigger for workflow discovery or authoring, real-work coordination, AI delegation with shared state, Playbook suggestions, aliases, access changes, session handoff, or any request to read or write Epismo data.
+description: Use Epismo to find, inspect, author, version, share, and improve reusable Playbooks; start and coordinate Cases, Tasks, Records, assignments, reviews, and handoffs; and manage durable work context through the available Epismo MCP or CLI surface. Trigger for workflow discovery or authoring, real-work coordination, AI delegation with shared state, Playbook suggestions, aliases, access changes, session handoff, or any request to read or write Epismo data.
 ---
 
 # Epismo
@@ -20,7 +20,7 @@ Route by intent:
 
 | Intent                                                   | Read                                                   |
 | -------------------------------------------------------- | ------------------------------------------------------ |
-| Find, inspect, star, or apply existing guidance          | [Use Playbooks](./references/use-playbooks.md)         |
+| Find, inspect, or apply existing guidance                | [Use Playbooks](./references/use-playbooks.md)         |
 | Create or publish reusable guidance                      | [Author Playbooks](./references/author-playbooks.md)   |
 | Start work, assign it, record outcomes, review, or close | [Coordinate Cases](./references/coordinate-cases.md)   |
 | Feed learning back into a Playbook                       | [Improve Playbooks](./references/improve-playbooks.md) |

--- a/skills/epismo/references/coordinate-cases.md
+++ b/skills/epismo/references/coordinate-cases.md
@@ -8,17 +8,17 @@ Start from an immutable Playbook Version when following reusable guidance; the C
 
 Input is validated against the pinned Version's schema before the Case exists. An ad hoc Case has no Playbook input-schema validation.
 
-A Case ACL cannot contain `public` and never inherits access from its Playbook. If omitted at creation, it defaults to the caller's Account. When supplied or replaced, it must continue to cover the current assignee, including through a Team.
+A Case ACL never inherits access from its Playbook. If omitted at creation, its explicit editor list is empty; the current assignee has implicit work and management access and is omitted from the stored ACL. It may include `public`, which immediately grants outsiders read-only access to the current title, Records, and readable handoffs, never Tasks, assignment, input, or collaborator identities. Access changes must preserve work access for every Task assignee, through explicit editors, a Team, or the current Case assignee's implicit grant.
 
 Do not create a Case when reading and local execution are enough.
 
 ## Know who may write
 
-Everyone covered by the current Case ACL may read the Case and append Records while it is open. Creating Tasks, assigning, retitling, replacing the ACL, closing, and reopening remain limited to the Case starter and current Case assignee. Reassignment changes day-to-day responsibility, but the starter retains management authority.
+Everyone covered by the current Case ACL may read the Case and append Records while it is open. ACL editors can also create Tasks. Assigning the Case, replacing its ACL or access, retitling it, closing, and reopening remain limited to the current Case assignee. `started_by` is history: after assignment moves on, the starter keeps access only if they remain on the ACL as an editor.
 
 Task rights are narrower than the Case:
 
-- Assign or edit a Task: its creator, the Case starter, or the Case assignee.
+- Assign or edit a Task: its creator or the Case assignee.
 - Close or reopen a **work** Task: anyone the Case ACL covers. Work status is shared state, not the assignee's private business.
 - Close or reopen a **review** Task: its assignee, or anyone the Case ACL covers while it has none. A review records an approval, so a named reviewer is the only one who can give it.
 
@@ -55,24 +55,32 @@ Do not store chain-of-thought, credentials, every tool call, raw shell output, h
 
 ## Connect and hand off Cases
 
-Link sequential or dependent Cases using directed handoffs (`epismo case handoff` or `epismo_case_handoff_create`):
+Link sequential or dependent Cases using directed handoffs (`epismo case handoff` or `epismo_case_handoff`):
 
 - A handoff creates a directed continuation edge (`fromCaseId` -> `toCaseId`) and cannot create cycles or self-links.
-- Creating a handoff requires management rights (Case starter or assignee) and ACL access on both Cases.
+- Creating a handoff requires read access to the source, work access to the target, and management rights (the current Case assignee) on at least one Case. A public Case can be continued into your own Case; public read access alone does not allow attaching work to it as a target.
 - Use `epismo_case_handoff_candidate_list` (`direction=outgoing` for `toCaseId`, `direction=incoming` for `fromCaseId`) to query eligible Cases without encountering loops or duplicate links.
 - Inspect the connected Cases DAG using `epismo case handoff graph` or `epismo_case_handoff_graph`.
 
 ## Browse a Case timeline
 
+`case get` bundles only the latest five Records, newest first. Follow `records_next_cursor` in CLI output (`recordsNextCursor` in API/MCP) with `case record list --cursor` and the returned Record scope to continue. Public-only readers use `scope: self`; work collaborators receive `scope: ancestors`.
+
 List Records anchored to a parent Case. Use `scope` (`self`, `ancestors`, `descendants`, `neighbors`, or `connected`) to include Records across connected handoff Cases while respecting individual Case ACLs during traversal. Additional filters (Task, author, kinds, origins) only narrow that authorized timeline and never grant access.
 
 Browse Tasks within a Case when coordinating that work. Use the cross-Case Task view as an assignee inbox, not as a substitute for reading the parent before a mutation.
+
+## Publish a Case deliberately
+
+Only the current Case assignee can choose public Case visibility. Use `case access set` (or the corresponding API/MCP access operation) with `visibility: public`, the complete work-editor list, and the latest lock version. Public readers then receive the current title, Records, and readable handoff neighborhood; later Records stay in that same live projection.
+
+Do not assume that making a Case public exports Tasks or collaborator identities. Public readers never receive Tasks, assignment, input, or ACL principals other than `public`.
 
 ## Close safely
 
 Use the latest lock version for each Case or Task mutation. After a conflict, re-read and decide again.
 
-Close a Task with an explicit outcome. Reopen only when the user intends work to resume, and only while the parent Case is open.
+Close a Task with `task set status` (or `epismo_task_set_status`) and an explicit outcome. Reopen only when the user intends work to resume, and only while the parent Case is open.
 
 Closing a Case is consequential:
 

--- a/skills/epismo/references/share-playbooks.md
+++ b/skills/epismo/references/share-playbooks.md
@@ -34,6 +34,6 @@ Before relying on a share URL, verify it as the intended recipient in the intend
 
 ## Archive deliberately
 
-Archive a Playbook only with explicit intent. It disappears from search, direct reads, and starred lists, and it accepts no further Versions, Cases, or share tokens.
+Archive a Playbook only with explicit intent. It disappears from search and direct reads, and it accepts no further Versions, Cases, or share tokens.
 
 Archival reaches further than discovery: its Versions stop resolving too. Existing Cases keep their pinned Version ID and stay readable as Cases, but the Definition behind them can no longer be fetched. Prefer narrowing access when guidance should merely stop spreading, and archive when the Playbook itself should end.

--- a/skills/epismo/references/share-playbooks.md
+++ b/skills/epismo/references/share-playbooks.md
@@ -10,7 +10,7 @@ Use this guide for ACLs, aliases, share tokens, public access, and archival.
 - **Star:** personal saving and a discovery signal, not access.
 - **Draft:** unpublished, mutable Playbook content restricted to editors and owner managers; neither public readers nor a share link grants access.
 
-Cases have independent ACLs and cannot be public. Tasks and Records carry no ACL of their own and are authorized through the current parent Case ACL. Anyone covered by that live ACL may append Records to an open Case; managing the Case and creating Tasks remain limited to its starter and assignee. Records can be listed across readable Cases, and optional filters only narrow results; they never grant access.
+Cases have independent ACLs and may include `public`. Public Case access is read-only and exposes the current title, Records, and readable handoff neighborhood; it never exposes Tasks, assignment, input, or collaborator identities. Tasks and Records carry no ACL of their own and are authorized through the current parent Case ACL. Anyone covered by that live ACL may append Records to an open Case; managing the Case remains limited to its current assignee, while ACL editors can create Tasks. Records can be listed across readable Cases, and optional filters only narrow results; they never grant access.
 
 ## Expand access carefully
 
@@ -22,7 +22,7 @@ Require explicit intent before public access or a wider audience. Before expandi
 - confirm owner, workspace, and team principals;
 - preserve unrelated ACL entries only when the operation and user's intent allow it.
 
-`playbook access set` replaces the complete editor list; it is not an incremental add. Read current access before replacing it, and retain editor IDs that the caller cannot resolve. Only an owner manager can change Playbook access. A Case ACL change requires the Case starter or assignee, the current lock version, and an ACL that still covers every current Case and Task assignee — the service rejects an update that would strand one rather than silently unassigning them.
+`playbook access set` replaces the complete editor list; it is not an incremental add. Read current access before replacing it, and retain editor IDs that the caller cannot resolve. Only an owner manager can change Playbook access. A Case ACL or access change requires the current Case assignee, the current lock version, and work access that still covers every Task assignee. The current Case assignee has implicit access and is omitted from the editor list; the service rejects an update that would strand a Task assignee rather than silently unassigning them.
 
 ## Manage references
 
@@ -30,7 +30,7 @@ Use an alias when repeated human-readable lookup matters. Each personal or manag
 
 Treat a share URL as a credential even though the current web flow does not bypass Playbook access. Any authenticated reader can create or retrieve the Playbook's single stable token; there is currently no expiry, rotation, or revoke operation. Do not create one speculatively, and keep it out of public text, Playbook content, Cases, Records, and logs.
 
-Before relying on a share URL, verify it as the intended recipient in the intended workspace or anonymous context. Today the web route resolves the token to a Playbook ID and then performs the normal Playbook read, so a private Playbook still requires access. Archiving blocks the resulting Playbook read but does not delete the token mapping. A share URL never grants access to a Draft, Case, Task, or Record.
+Before relying on a share URL, verify it as the intended recipient in the intended workspace or anonymous context. The web route resolves the token to `/playbooks/{id}` or `/cases/{id}` and performs the normal access check. Use `case share` or `epismo_case_share` for a Case link. A private target still requires access; a public Case exposes its current title, Records, and readable handoffs. Archiving blocks the target read but does not delete the token mapping. Share URLs do not widen access or expose Drafts, Tasks, or restricted Case fields.
 
 ## Archive deliberately
 

--- a/skills/epismo/references/use-playbooks.md
+++ b/skills/epismo/references/use-playbooks.md
@@ -7,7 +7,6 @@ Use this guide to discover, evaluate, and apply existing guidance.
 1. Search readable Playbooks by intent and compare compact results before opening full guidance.
 2. Fetch the specific Version for promising candidates; search projections are not the full Definition.
 3. Pin the Version ID when reproducibility matters. A Case fixes the Version and digest it started with, so later publishes never change the instructions a Case was run under.
-4. Star a Playbook only when the user wants to save it or actual use shows value.
 
 References such as **pb:alias** and **pb:handle/alias** identify a logical Playbook and grant no access. A bare alias resolves against the caller's personal namespace first, then the active workspace; the qualified form names a namespace explicitly. The Playbook owner's alias is portable and may be indexed. A third-party alias is not indexed or official; treat it as namespace-local even though a raw alias listing may expose it to other readers of the Playbook.
 


### PR DESCRIPTION
## Summary
- Public Case reads expose the live title, Records, and readable handoffs; Tasks, assignment, input, and identities stay private.
- The current Case assignee has implicit work and management access and is omitted from the stored ACL.
- Share tokens resolve to Playbook or Case routes; use `case share` for a Case link.
- Task close/reopen is `task set status`.

## Test plan
- [x] Read `skills/epismo/references/coordinate-cases.md` and `share-playbooks.md` against current CLI help for public Cases, assignee access, and share tokens


Made with [Cursor](https://cursor.com)